### PR TITLE
fix(golang): fix golang import-replace functionality

### DIFF
--- a/generator/golang/option.go
+++ b/generator/golang/option.go
@@ -78,13 +78,13 @@ var codeUtilsParams = []*param{
 		name: "thrift_import_path",
 		desc: "Override thrift package import path (default:github.com/apache/thrift/lib/go/thrift)",
 		action: func(value string, cu *CodeUtils) error {
-			cu.UsePackage("thrift", value)
+			cu.UsePackage(DefaultThriftLib, value)
 			return nil
 		},
 	},
 	{
 		name: "use_package",
-		desc: "Specify an import path for a package. Form: 'pkg=path'",
+		desc: "Specify an import path replacement. Form: 'path=repl', (e.g. 'database/sql/driver=example.com/my/dirver')",
 		action: func(value string, cu *CodeUtils) error {
 			parts := strings.SplitN(value, "=", 2)
 			if len(parts) < 2 {

--- a/generator/golang/util.go
+++ b/generator/golang/util.go
@@ -41,7 +41,7 @@ var escape = regexp.MustCompile(`\\.`)
 type CodeUtils struct {
 	backend.LogFunc
 	packagePrefix string            // Package prefix for all generated codes.
-	customized    map[string]string // Customized imports, package => import path.
+	importReplace map[string]string // Customized imports, import path => replacement.
 	features      Features          // Available features.
 	namingStyle   styles.Naming     // Naming style.
 	doInitialisms bool              // Make initialisms setting kept event naming style changes.
@@ -53,11 +53,11 @@ type CodeUtils struct {
 // NewCodeUtils creates a new CodeUtils.
 func NewCodeUtils(log backend.LogFunc) *CodeUtils {
 	cu := &CodeUtils{
-		LogFunc:     log,
-		customized:  make(map[string]string),
-		features:    defaultFeatures,
-		namingStyle: styles.NewNamingStyle("thriftgo"),
-		scopeCache:  make(map[*parser.Thrift]*Scope),
+		LogFunc:       log,
+		importReplace: make(map[string]string),
+		features:      defaultFeatures,
+		namingStyle:   styles.NewNamingStyle("thriftgo"),
+		scopeCache:    make(map[*parser.Thrift]*Scope),
 	}
 	return cu
 }
@@ -83,8 +83,8 @@ func (cu *CodeUtils) SetPackagePrefix(pp string) {
 }
 
 // UsePackage forces the generated codes to use the specific package.
-func (cu *CodeUtils) UsePackage(pkg, path string) {
-	cu.customized[pkg] = path
+func (cu *CodeUtils) UsePackage(path, repl string) {
+	cu.importReplace[path] = repl
 }
 
 // NamingStyle returns the current naming style.


### PR DESCRIPTION
The behaviors of golang option `thrift_import_path` and `use_package` do not work as expected. The golang backend manages imports with a namespace.Namespace and adds new `(package-name, import-path)` pair to the namespace when the user customizes an import. But that results a new import statement rather than replacing the target one and causes compile error as described in #34 .

This pr fixes the issue by adding a helper type `idHijack`. It replaces import paths -- which are ID roles in the namespace -- to support customization and thus avoids unused import.

Also, the parameter pattern of `use_package` should be modified to a new manner that accepts two import paths. Since this     bug is first found, we can be confident that there is no historical usage of this option and it is safe to change its semantics.

closes #34 and #35 