### PR TITLE
fix: enum use original type name in frugal tag

### DIFF
--- a/generator/golang/frugal.go
+++ b/generator/golang/frugal.go
@@ -62,9 +62,6 @@ func (r *FrugalResolver) getTypeName(g *Scope, t *parser.Type) (name string, err
 	if isContainerTypes[t.Name] {
 		return r.getContainerTypeName(g, t)
 	}
-	if t.Category.IsEnum() {
-		return "i64", nil
-	}
 	g, ut, name := getUnderlay(g, t)
 
 	if name == "" {


### PR DESCRIPTION
#### What type of PR is this?
fix

#### What this PR does / why we need it (en: English/zh: Chinese):
en: enum use original type name in frugal tag
zh: frugal tag中枚举使用本来的类型名

#### Which issue(s) this PR fixes:
none
