### PR TITLE
fix: fix requiredness of throws

### DIFF
--- a/semantic/checker.go
+++ b/semantic/checker.go
@@ -201,6 +201,19 @@ func (c *checker) CheckFunctions(t *parser.Thrift) (warns []string, err error) {
 						a.ID, a.Name, svc.Name, f.Name))
 				}
 			}
+			for _, a := range f.Throws {
+				switch a.Requiredness {
+				case parser.FieldType_Required:
+					warns = append(warns, fmt.Sprintf("exception %q in %q.%q: throw field must be optional, ignoring specified requiredness.",
+						a.Name, svc.Name, f.Name))
+					if !c.FixWarnings {
+						continue
+					}
+					fallthrough
+				case parser.FieldType_Default:
+					a.Requiredness = parser.FieldType_Optional
+				}
+			}
 		}
 	}
 	if argOpt != "" {


### PR DESCRIPTION
## Description
fix requiredness of throws which should be `optional` instead of `default`


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
when a method has at least one exception, it will always return an exception
<!--- If it fixes an open issue, please link to the issue here. -->
none

## Related Issue
<!-- use words like 'fix #123', 'closes #123' -->
none
