### PR TITLE
feat(golang): support generating snake-style json tag

### DIFF
--- a/generator/golang/option.go
+++ b/generator/golang/option.go
@@ -42,7 +42,8 @@ type Features struct {
 	FrugalTag          bool `frugal_tag:"Generate 'frugal' tags."`
 	EscapeDoubleInTag  bool `unescape_double_quote:"Unescape the double quotes in literals when generating go tags."`
 	GenerateTypeMeta   bool `gen_type_meta:"Generate and register type meta for structures."`
-	GenerateJsonTag    bool `gen_json_tag:"Generate struct with 'json' tag"`
+	GenerateJSONTag    bool `gen_json_tag:"Generate struct with 'json' tag"`
+	SnakeTyleJSONTag   bool `snake_style_json_tag:"Generate snake style json tag"`
 }
 
 var defaultFeatures = Features{
@@ -64,7 +65,8 @@ var defaultFeatures = Features{
 	FrugalTag:          false,
 	EscapeDoubleInTag:  true,
 	GenerateTypeMeta:   false,
-	GenerateJsonTag:    true,
+	GenerateJSONTag:    true,
+	SnakeTyleJSONTag:   false,
 }
 
 type param struct {

--- a/generator/golang/util.go
+++ b/generator/golang/util.go
@@ -249,11 +249,15 @@ func (cu *CodeUtils) genFieldTags(f *parser.Field, insertPoint string, extend []
 			tags = append(tags, fmt.Sprintf(`db:"%s"`, f.Name))
 		}
 
-		if cu.Features().GenerateJsonTag {
+		if cu.Features().GenerateJSONTag {
+			id := f.Name
+			if cu.Features().SnakeTyleJSONTag {
+				id = snakify(id)
+			}
 			if f.Requiredness.IsOptional() && cu.Features().GenOmitEmptyTag {
-				tags = append(tags, fmt.Sprintf(`json:"%s,omitempty"`, f.Name))
+				tags = append(tags, fmt.Sprintf(`json:"%s,omitempty"`, id))
 			} else {
-				tags = append(tags, fmt.Sprintf(`json:"%s"`, f.Name))
+				tags = append(tags, fmt.Sprintf(`json:"%s"`, id))
 			}
 		}
 	}
@@ -364,4 +368,15 @@ func (cu *CodeUtils) BuildFuncMap() template.FuncMap {
 		},
 	}
 	return m
+}
+
+var (
+	snakeRE1 = regexp.MustCompile(`([^_])([A-Z][a-z]+)`)
+	snakeRE2 = regexp.MustCompile(`([a-z0-9])([A-Z])`)
+)
+
+func snakify(id string) string {
+	id = snakeRE1.ReplaceAllString(id, `${1}_${2}`)
+	id = snakeRE2.ReplaceAllString(id, `${1}_${2}`)
+	return strings.ToLower(id)
 }

--- a/generator/golang/util_test.go
+++ b/generator/golang/util_test.go
@@ -1,3 +1,17 @@
+// Copyright 2022 CloudWeGo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package golang
 
 import "testing"

--- a/generator/golang/util_test.go
+++ b/generator/golang/util_test.go
@@ -1,0 +1,21 @@
+package golang
+
+import "testing"
+
+func TestSnakify(t *testing.T) {
+	cases := []struct{ original, expected string }{
+		{"a", "a"},
+		{"A", "a"},
+		{"AB", "ab"},
+		{"HTTPRequest", "http_request"},
+		{"HTTP1Method", "http1_method"},
+		{"GetUserIP", "get_user_ip"},
+	}
+	for _, c := range cases {
+		res := snakify(c.original)
+		if res != c.expected {
+			t.Logf("snakify(%q) => %q. Expected: %q", c.original, res, c.expected)
+			t.Fail()
+		}
+	}
+}


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

Add an option `snake-style-json-tag` to make golang backend generate snake-style json tag. Examples:

```
a => a
A => a
AB => ab
HTTPRequest => http_request
HTTP1Method => http1_method
GetUserIP => get_user_ip
```

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


## Related Issue
<!-- use words like 'fix #123', 'closes #123' -->
