### PR TITLE
fix: fix package reference of constant value

### DIFF
--- a/generator/golang/resolver.go
+++ b/generator/golang/resolver.go
@@ -182,7 +182,9 @@ func (r *Resolver) getIDValue(g *Scope, extra *parser.ConstValueExtra) (v string
 		}
 		return r.getIDValue(g, extra)
 	}
-	if v != "" && g != r.root {
+	rootPkg := r.util.GetPackageName(r.root.ast)
+	constPkg := r.util.GetPackageName(g.ast)
+	if v != "" && rootPkg != constPkg {
 		pkg := r.root.includeIDL(r.util, g.ast)
 		v = pkg + "." + v
 	}


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
fix unnecessary package reference of constant value when the package of constant value is the same as the root thrift package

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
this a bug that may cause a compilation error

## Related Issue
<!-- use words like 'fix #123', 'closes #123' -->
none