### PR TITLE
fix: fix unnecessary import of slim template

### DIFF
--- a/generator/golang/templates/slim/slim.go
+++ b/generator/golang/templates/slim/slim.go
@@ -108,6 +108,15 @@ func (p *{{$TypeName}}) Error() string {
 	Processor = `
 {{define "Processor"}}
 {{InsertionPoint "slim.Processor"}}
+{{$throws := ServiceThrows .}}
+{{- if $throws}}
+// exceptions of methods in {{.GoName}}.
+var (
+{{- range $throws}}
+_ error = ({{.GoTypeName}})(nil)
+{{- end}}{{/* range $throws */}}
+)
+{{- end}}{{/* if $throws */}}
 {{- end}}{{/* define "Processor" */}}
-	`
+`
 )

--- a/generator/golang/util.go
+++ b/generator/golang/util.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"path/filepath"
 	"regexp"
+	"sort"
 	"strings"
 	"text/template"
 
@@ -365,6 +366,22 @@ func (cu *CodeUtils) BuildFuncMap() template.FuncMap {
 				return fmt.Sprintf("<%s>", err.Error())
 			}
 			return prettifyBytesLiteral(fmt.Sprintf("%#v", bs))
+		},
+		"ServiceThrows": func(svc *Service) []*Field {
+			fm := make(map[string]*Field)
+			for _, f := range svc.Functions() {
+				for _, e := range f.Throws() {
+					fm[string(e.GoTypeName())] = e
+				}
+			}
+			ret := make([]*Field, 0, len(fm))
+			for _, e := range fm {
+				ret = append(ret, e)
+			}
+			sort.Slice(ret, func(i, j int) bool {
+				return ret[i].GoTypeName().String() < ret[j].GoTypeName().String()
+			})
+			return ret
 		},
 	}
 	return m


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
add import guard for exceptions in slim template

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
thriftgo won't generate the result struct when using slim template, so there should be an import guard to prevent unused imports of exceptions

## Related Issue
<!-- use words like 'fix #123', 'closes #123' -->
none