### PR TITLE
fix: when the api.body annotation exists, the generated struct fields…

### DIFF
--- a/generator/golang/util.go
+++ b/generator/golang/util.go
@@ -250,15 +250,25 @@ func (cu *CodeUtils) genFieldTags(f *parser.Field, insertPoint string, extend []
 			tags = append(tags, fmt.Sprintf(`db:"%s"`, f.Name))
 		}
 
-		if cu.Features().GenerateJSONTag {
-			id := f.Name
-			if cu.Features().SnakeTyleJSONTag {
-				id = snakify(id)
+		var existsApiBodyAnno bool
+		for _, anno := range f.Annotations {
+			if anno.Key == "api.body" {
+				existsApiBodyAnno = true
+				break
 			}
-			if f.Requiredness.IsOptional() && cu.Features().GenOmitEmptyTag {
-				tags = append(tags, fmt.Sprintf(`json:"%s,omitempty"`, id))
-			} else {
-				tags = append(tags, fmt.Sprintf(`json:"%s"`, id))
+		}
+
+		if !existsApiBodyAnno {
+			if cu.Features().GenerateJSONTag {
+				id := f.Name
+				if cu.Features().SnakeTyleJSONTag {
+					id = snakify(id)
+				}
+				if f.Requiredness.IsOptional() && cu.Features().GenOmitEmptyTag {
+					tags = append(tags, fmt.Sprintf(`json:"%s,omitempty"`, id))
+				} else {
+					tags = append(tags, fmt.Sprintf(`json:"%s"`, id))
+				}
 			}
 		}
 	}


### PR DESCRIPTION
struct in thrift file:
```thrift
struct User {
    1: i32 ID (api.body="id");
    2: string Name (api.body="name");
}
```
the structure in the generated go file:
```go
type User struct {
	ID   int32  `thrift:"ID,1" json:"ID" form:"ID" json:"id" query:"ID"`
	Name string `thrift:"Name,2" json:"ID" form:"Name" json:"name" query:"Name"`
}
```
will cause api.body to fail.