### PR TITLE
fix: fix error value name for the same namespace

### DIFF
--- a/generator/golang/resolver.go
+++ b/generator/golang/resolver.go
@@ -182,7 +182,7 @@ func (r *Resolver) getIDValue(g *Scope, extra *parser.ConstValueExtra) (v string
 		}
 		return r.getIDValue(g, extra)
 	}
-	if v != "" && g != r.root {
+	if v != "" && g.namespace != r.root.namespace {
 		pkg := r.root.includeIDL(r.util, g.ast)
 		v = pkg + "." + v
 	}


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
当两个文件的namespace 相同时，生成的代码的变量名可能会多一层引用

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


## Related Issue
<!-- use words like 'fix #123', 'closes #123' -->
