### PR TITLE
feat: added escaping for: for to adapt windows path

### DIFF
--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -65,9 +65,13 @@ func ParseCompactArguments(str string) (*Desc, error) {
 		return nil, errors.New("ParseArguments: empty string")
 	}
 	desc := new(Desc)
+	// to escape :,
+	str = strings.ReplaceAll(str, "\\:", "$$$")
 	args := strings.SplitN(str, ":", 2)
+	args[0] = strings.ReplaceAll(args[0], "$$$", ":")
 	desc.Name = args[0]
 	if len(args) > 1 {
+		args[1] = strings.ReplaceAll(args[1], "$$$", ":")
 		for _, a := range strings.Split(args[1], ",") {
 			var opt Option
 			kv := strings.SplitN(a, "=", 2)


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
On Windows platforms, colons are used in paths as part of the drive letter, which can cause incorrect parsing as command arguments. Escaped colons (\\:) are handled here so that they can be properly escaped

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Adaptation changes made for Windows platform support for kitex

## Related Issue
<!-- use words like 'fix #123', 'closes #123' -->
fix https://github.com/cloudwego/kitex/issues/469