### PR TITLE
fix: wrong package name for windows

### DIFF
--- a/generator/golang/backend.go
+++ b/generator/golang/backend.go
@@ -174,7 +174,7 @@ func (g *GoBackend) renderOneFile(ast *parser.Thrift) error {
 	if doRef {
 		executeTpl = g.refTpl
 		scope.refPath = refPath
-		arr := strings.Split(refPath, "/")
+		arr := strings.Split(refPath, string(filepath.Separator))
 		scope.refPackage = arr[len(arr)-1]
 	}
 	err = executeTpl.ExecuteTemplate(&buf, g.tpl.Name(), scope)

--- a/generator/golang/scope.go
+++ b/generator/golang/scope.go
@@ -16,6 +16,7 @@ package golang
 
 import (
 	"fmt"
+	"path/filepath"
 	"strings"
 
 	"github.com/cloudwego/thriftgo/parser"
@@ -88,7 +89,7 @@ func BuildScope(cu *CodeUtils, ast *parser.Thrift) (*Scope, error) {
 	cu.scopeCache[ast] = scope
 	pth := cu.CombineOutputPath(cu.packagePrefix, ast)
 	scope.importPath = pth
-	parts := strings.Split(scope.importPath, "/")
+	parts := strings.Split(scope.importPath, string(filepath.Separator))
 	scope.importPackage = strings.ToLower(parts[len(parts)-1])
 	return scope, nil
 }


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
在获取包名的时候，使用"filepath.Separator"作为分隔符，从而在windows下也好用。

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


## Related Issue
<!-- use words like 'fix #123', 'closes #123' -->
fix #76 