### PR TITLE
fix: fix typedef struct alias

### DIFF
--- a/generator/golang/templates/typedef.go
+++ b/generator/golang/templates/typedef.go
@@ -28,7 +28,7 @@ type {{$NewTypeName}} {{$OldTypeName}}
 
 {{if .Type.Category.IsStructLike}} 
 func New{{$NewTypeName}}() *{{$NewTypeName}} {
-	return {{$OldTypeName.NewFunc}}()
+	return (*{{$NewTypeName}})({{$OldTypeName.NewFunc}}())
 }
 {{- end}}{{/* if .Type.Category.IsStructLike */}} 
 {{- end}}{{/* define "Typedef" */}}


### PR DESCRIPTION
## Description

fix typedef alias error when old type is struct.


## Motivation and Context

With thrift file test.thrift:
```
namespace go test

struct Req {
    1: required i64 id,
}
```
typedef Req Req2

Before this commit, the generated code is like:
```
type Req2 Req

func NewReq2() *Req2 {
	return NewReq()
}
```
which causes compiling error.

Now it looks like this:
```
type Req2 Req

func NewReq2() *Req2 {
	return (*Req2)(NewReq())
}
```

## Related Issue
#79 
