### PR TITLE
fix: package_prefix error under windows

### DIFF
--- a/generator/golang/scope.go
+++ b/generator/golang/scope.go
@@ -90,8 +90,8 @@ func BuildScope(cu *CodeUtils, ast *parser.Thrift) (*Scope, error) {
 	}
 	cu.scopeCache[ast] = scope
 	pth := cu.CombineOutputPath(cu.packagePrefix, ast)
-	scope.importPath = pth
-	parts := strings.Split(scope.importPath, string(filepath.Separator))
+	scope.importPath = pathToImport(pth)
+	parts := strings.Split(scope.importPath, "/")
 	scope.importPackage = strings.ToLower(parts[len(parts)-1])
 	return scope, nil
 }

--- a/generator/golang/util.go
+++ b/generator/golang/util.go
@@ -444,3 +444,7 @@ func lowerCamelCase(id string) string {
 	}
 	return strings.Join(words, "")
 }
+
+func pathToImport(path string) string {
+	return strings.ReplaceAll(path, string(filepath.Separator), "/")
+}


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
指定"package_prefix"后，windows 下生成代码的 import 路径有问题，原因是在对 import 进行操作的时候带进去了"windows"下的路径分隔符"\"，而 go import 的分隔符 "/"

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


## Related Issue
<!-- use words like 'fix #123', 'closes #123' -->
