### PR TITLE
Generate json tag even if go.tag exists

### DIFF
--- a/generator/golang/util_test.go
+++ b/generator/golang/util_test.go
@@ -55,3 +55,40 @@ func TestLowerCamelCase(t *testing.T) {
 		}
 	}
 }
+
+func TestGotagsContains(t *testing.T) {
+	cases := []struct {
+		gotags    []string
+		tagPrefix string
+		ret       bool
+	}{
+		{
+			[]string{},
+			"json",
+			false,
+		},
+		{
+			[]string{`thrift:"name"`},
+			"json",
+			false,
+		},
+		{
+			[]string{`json:"name"`},
+			"json",
+			true,
+		},
+		{
+			[]string{`thrift:"name" json:"name"`},
+			"json",
+			true,
+		},
+	}
+
+	for _, c := range cases {
+		ret := gotagsContains(c.gotags, c.tagPrefix)
+		if ret != c.ret {
+			t.Logf("gotagsContains(%q, %q) => %v. Expected: %v", c.gotags, c.tagPrefix, ret, c.ret)
+			t.Fail()
+		}
+	}
+}

--- a/generator/golang/util_test.go
+++ b/generator/golang/util_test.go
@@ -63,24 +63,16 @@ func TestGotagsContains(t *testing.T) {
 		ret       bool
 	}{
 		{
-			[]string{},
-			"json",
-			false,
+			[]string{}, "json", false,
 		},
 		{
-			[]string{`thrift:"name"`},
-			"json",
-			false,
+			[]string{`thrift:"name"`}, "json", false,
 		},
 		{
-			[]string{`json:"name"`},
-			"json",
-			true,
+			[]string{`json:"name"`}, "json", true,
 		},
 		{
-			[]string{`thrift:"name" json:"name"`},
-			"json",
-			true,
+			[]string{`thrift:"name" json:"name"`}, "json", true,
 		},
 	}
 

--- a/generator/golang/util_test.go
+++ b/generator/golang/util_test.go
@@ -62,20 +62,11 @@ func TestGotagsContains(t *testing.T) {
 		tagPrefix string
 		ret       bool
 	}{
-		{
-			[]string{}, "json", false,
-		},
-		{
-			[]string{`thrift:"name"`}, "json", false,
-		},
-		{
-			[]string{`json:"name"`}, "json", true,
-		},
-		{
-			[]string{`thrift:"name" json:"name"`}, "json", true,
-		},
+		{[]string{}, "json", false},
+		{[]string{`thrift:"name"`}, "json", false},
+		{[]string{`json:"name"`}, "json", true},
+		{[]string{`thrift:"name" json:"name"`}, "json", true},
 	}
-
 	for _, c := range cases {
 		ret := gotagsContains(c.gotags, c.tagPrefix)
 		if ret != c.ret {


### PR DESCRIPTION
## Description
Still generate json tag even if gotag is provided, but not if gotag has json tag

## Motivation and Context
If gotag is provided in thrift file, json tag will not be generated.
