### PR TITLE
feat: add option always_gen_json_tag

### DIFF
--- a/generator/golang/option.go
+++ b/generator/golang/option.go
@@ -43,6 +43,7 @@ type Features struct {
 	EscapeDoubleInTag      bool `unescape_double_quote:"Unescape the double quotes in literals when generating go tags."`
 	GenerateTypeMeta       bool `gen_type_meta:"Generate and register type meta for structures."`
 	GenerateJSONTag        bool `gen_json_tag:"Generate struct with 'json' tag"`
+	AlwaysGenerateJSONTag  bool `always_gen_json_tag:"Always generate 'json' tag even if go.tag is provided (Disabled by default)"`
 	SnakeTyleJSONTag       bool `snake_style_json_tag:"Generate snake style json tag"`
 	LowerCamelCaseJSONTag  bool `lower_camel_style_json_tag:"Generate lower camel case style json tag"`
 	GenerateReflectionInfo bool `generate_reflection_info:"Generate reflection info json"`
@@ -69,6 +70,7 @@ var defaultFeatures = Features{
 	EscapeDoubleInTag:      true,
 	GenerateTypeMeta:       false,
 	GenerateJSONTag:        true,
+	AlwaysGenerateJSONTag:  false,
 	SnakeTyleJSONTag:       false,
 	LowerCamelCaseJSONTag:  false,
 	GenerateReflectionInfo: false,

--- a/generator/golang/util.go
+++ b/generator/golang/util.go
@@ -265,7 +265,8 @@ func (cu *CodeUtils) genFieldTags(f *parser.Field, insertPoint string, extend []
 
 	tags = append(tags, extend...)
 
-	if gotags := f.Annotations.Get("go.tag"); len(gotags) > 0 {
+	gotags := f.Annotations.Get("go.tag")
+	if len(gotags) > 0 {
 		tag := gotags[0]
 		if cu.Features().EscapeDoubleInTag {
 			tag = escape.ReplaceAllStringFunc(tag, func(m string) string {
@@ -280,23 +281,24 @@ func (cu *CodeUtils) genFieldTags(f *parser.Field, insertPoint string, extend []
 		if cu.Features().GenDatabaseTag {
 			tags = append(tags, fmt.Sprintf(`db:"%s"`, f.Name))
 		}
+	}
 
-		if cu.Features().GenerateJSONTag {
-			id := f.Name
-			if cu.Features().SnakeTyleJSONTag {
-				id = snakify(id)
-			}
-			if cu.Features().LowerCamelCaseJSONTag {
-				id = lowerCamelCase(id)
-			}
+	if len(gotags) == 0 && cu.Features().GenerateJSONTag || cu.Features().AlwaysGenerateJSONTag {
+		id := f.Name
+		if cu.Features().SnakeTyleJSONTag {
+			id = snakify(id)
+		}
+		if cu.Features().LowerCamelCaseJSONTag {
+			id = lowerCamelCase(id)
+		}
 
-			if f.Requiredness.IsOptional() && cu.Features().GenOmitEmptyTag {
-				tags = append(tags, fmt.Sprintf(`json:"%s,omitempty"`, id))
-			} else {
-				tags = append(tags, fmt.Sprintf(`json:"%s"`, id))
-			}
+		if f.Requiredness.IsOptional() && cu.Features().GenOmitEmptyTag {
+			tags = append(tags, fmt.Sprintf(`json:"%s,omitempty"`, id))
+		} else {
+			tags = append(tags, fmt.Sprintf(`json:"%s"`, id))
 		}
 	}
+
 	str := fmt.Sprintf("`%s%s`", strings.Join(tags, " "), insertPoint)
 	return str, nil
 }


### PR DESCRIPTION
## Description
Add an option `always_gen_json_tag` to generate json tag even if gotag is provided.

### Example
Assume we have a thrift like this:
```
// user.thrift
struct User {
    1: string Name (go.tag="platform:\"1\"")
}
```

Before this PR, `thriftgo -g go user.thrift` generates code without json tag
```go
type User struct {
    Name string `thrift:"Name,1" platform:"1"`
}
```

After this PR, `thriftgo -g go:always_gen_json_tag user.thrift` will bring back the json tag
```go
type User struct {
    Name string `thrift:"Name,1" platform:"1" json:"name"`
}
```


## Motivation and Context
If gotag is provided in thrift file, json tag will not be generated.
