### PR TITLE
feat: support generate nested struct for slim template

### DIFF
--- a/args.go
+++ b/args.go
@@ -104,6 +104,7 @@ func (a *Arguments) Targets() (specs []*generator.LangSpec, err error) {
 		if err != nil {
 			return nil, err
 		}
+		// checkOptions may modify the content of the options
 		desc.Options = opts
 		spec := &generator.LangSpec{
 			Language: desc.Name,
@@ -114,11 +115,13 @@ func (a *Arguments) Targets() (specs []*generator.LangSpec, err error) {
 	return
 }
 
+// checkOptions used to validate the command parameters.
 func (a *Arguments) checkOptions(opts []plugin.Option) ([]plugin.Option, error) {
 	params := plugin.Pack(opts)
 	cu := golang.NewCodeUtils(backend.DummyLogFunc())
 	cu.HandleOptions(params)
 	if cu.Features().EnableNestedStruct {
+		// In nested mode, if template is not 'slim', it is automatically converted to slim
 		if cu.Template() != "slim" {
 			found := false
 			for _, opt := range opts {

--- a/args.go
+++ b/args.go
@@ -15,7 +15,6 @@
 package main
 
 import (
-	"errors"
 	"flag"
 	"fmt"
 	"log"
@@ -120,7 +119,8 @@ func (a *Arguments) checkOptions(opt []plugin.Option) error {
 	cu.HandleOptions(params)
 	if cu.Features().EnableNestedStruct {
 		if cu.Template() != "slim" {
-			return errors.New("EnableNestedStruct is only available under the \"slim\" template, example: -go:template=slim,enable_nested_struct")
+			log.Printf("[WARN] EnableNestedStruct is only available under the \"slim\" template, so adapt the template to \"slim\"")
+			cu.SetTemplate("slim")
 		}
 	}
 	return nil

--- a/generator/golang/option.go
+++ b/generator/golang/option.go
@@ -55,13 +55,13 @@ type Features struct {
 	CodeRef                bool `code_ref:"Genenerate code ref by given idl-ref.yaml"`
 	KeepCodeRefName        bool `keep_code_ref_name:"Genenerate code ref but still keep file name."`
 	TrimIDL                bool `trim_idl:"Simplify IDL to the most concise form before generating code."`
+	EnableNestedStruct     bool `enable_nested_struct:"Generate nested field when 'type name' equal to 'field name', valid only in 'slim template'"`
 
 	JSONStringer bool `json_stringer:"Generate the JSON marshal method in String() method."`
 
 	WithFieldMask         bool `with_field_mask:"Support field-mask for generated code."`
 	FieldMaskHalfway      bool `field_mask_halfway:"Support set field-mask on not-root struct."`
 	FieldMaskZeroRequired bool `field_mask_zero_required:"Write zero value instead of current value for required fields filtered by fieldmask."`
-	EnableNestedStruct     bool `enable_nested_struct:"Generate nested struct when fiele name is \"_\", valid only in 'slim template'"`
 }
 
 var defaultFeatures = Features{

--- a/generator/golang/option.go
+++ b/generator/golang/option.go
@@ -55,12 +55,11 @@ type Features struct {
 	CodeRef                bool `code_ref:"Genenerate code ref by given idl-ref.yaml"`
 	KeepCodeRefName        bool `keep_code_ref_name:"Genenerate code ref but still keep file name."`
 	TrimIDL                bool `trim_idl:"Simplify IDL to the most concise form before generating code."`
-	EnableNestedStruct     bool `enable_nested_struct:"Generate nested field when 'field name' ends with 'Nested' , valid only in 'slim template'"`
-	JSONStringer bool `json_stringer:"Generate the JSON marshal method in String() method."`
-
-	WithFieldMask         bool `with_field_mask:"Support field-mask for generated code."`
-	FieldMaskHalfway      bool `field_mask_halfway:"Support set field-mask on not-root struct."`
-	FieldMaskZeroRequired bool `field_mask_zero_required:"Write zero value instead of current value for required fields filtered by fieldmask."`
+	EnableNestedStruct     bool `enable_nested_struct:"Generate nested field when 'thrift.nested=\"true\"' annotation is set to field, valid only in 'slim template'"`
+	JSONStringer           bool `json_stringer:"Generate the JSON marshal method in String() method."`
+	WithFieldMask          bool `with_field_mask:"Support field-mask for generated code."`
+	FieldMaskHalfway       bool `field_mask_halfway:"Support set field-mask on not-root struct."`
+	FieldMaskZeroRequired  bool `field_mask_zero_required:"Write zero value instead of current value for required fields filtered by fieldmask."`
 }
 
 var defaultFeatures = Features{

--- a/generator/golang/option.go
+++ b/generator/golang/option.go
@@ -61,6 +61,7 @@ type Features struct {
 	WithFieldMask         bool `with_field_mask:"Support field-mask for generated code."`
 	FieldMaskHalfway      bool `field_mask_halfway:"Support set field-mask on not-root struct."`
 	FieldMaskZeroRequired bool `field_mask_zero_required:"Write zero value instead of current value for required fields filtered by fieldmask."`
+	EnableNestedStruct     bool `enable_nested_struct:"Generate nested struct when fiele name is \"_\", valid only in 'slim template'"`
 }
 
 var defaultFeatures = Features{
@@ -95,6 +96,7 @@ var defaultFeatures = Features{
 	WithFieldMask:          false,
 	FieldMaskHalfway:       false,
 	FieldMaskZeroRequired:  false,
+	EnableNestedStruct:     false,
 }
 
 type param struct {

--- a/generator/golang/option.go
+++ b/generator/golang/option.go
@@ -55,8 +55,7 @@ type Features struct {
 	CodeRef                bool `code_ref:"Genenerate code ref by given idl-ref.yaml"`
 	KeepCodeRefName        bool `keep_code_ref_name:"Genenerate code ref but still keep file name."`
 	TrimIDL                bool `trim_idl:"Simplify IDL to the most concise form before generating code."`
-	EnableNestedStruct     bool `enable_nested_struct:"Generate nested field when 'type name' equal to 'field name', valid only in 'slim template'"`
-
+	EnableNestedStruct     bool `enable_nested_struct:"Generate nested field when 'field name' ends with 'Nested' , valid only in 'slim template'"`
 	JSONStringer bool `json_stringer:"Generate the JSON marshal method in String() method."`
 
 	WithFieldMask         bool `with_field_mask:"Support field-mask for generated code."`

--- a/generator/golang/scope.go
+++ b/generator/golang/scope.go
@@ -23,6 +23,7 @@ import (
 	"github.com/cloudwego/thriftgo/pkg/namespace"
 	"github.com/cloudwego/thriftgo/reflection"
 	"github.com/cloudwego/thriftgo/thrift_reflection"
+	"github.com/cloudwego/thriftgo/reflection"
 )
 
 // Name is the type of identifiers converted from a thrift AST to Go code.
@@ -496,6 +497,7 @@ type Field struct {
 	setter          Name
 	isset           Name
 	deepEqual       Name
+	isNested        bool
 }
 
 // GoName returns the name in go code of the field.
@@ -553,6 +555,11 @@ func (f *Field) IsSetter() Name {
 // DeepEqual returns the deep compare method's name for the field.
 func (f *Field) DeepEqual() Name {
 	return f.deepEqual
+}
+
+// IsNested returns whether the field is a nested type.
+func (f *Field) IsNested() bool {
+	return f.isNested
 }
 
 // StructLike is a wrapper for the parser.StructLike.

--- a/generator/golang/scope.go
+++ b/generator/golang/scope.go
@@ -23,7 +23,6 @@ import (
 	"github.com/cloudwego/thriftgo/pkg/namespace"
 	"github.com/cloudwego/thriftgo/reflection"
 	"github.com/cloudwego/thriftgo/thrift_reflection"
-	"github.com/cloudwego/thriftgo/reflection"
 )
 
 // Name is the type of identifiers converted from a thrift AST to Go code.

--- a/generator/golang/scope_internal.go
+++ b/generator/golang/scope_internal.go
@@ -127,12 +127,6 @@ func (s *Scope) identify(cu *CodeUtils, raw string) string {
 	if err != nil {
 		panic(err)
 	}
-	// Because EnableNestedStruct generates nested struct, the variable name is empty when the raw name is "_".
-	if cu.Features().EnableNestedStruct {
-		if raw == "_" {
-			name = ""
-		}
-	}
 	if !strings.HasPrefix(raw, prefix) && cu.Features().CompatibleNames {
 		if strings.HasPrefix(name, "New") || strings.HasSuffix(name, "Args") || strings.HasSuffix(name, "Result") {
 			name += "_"
@@ -327,14 +321,15 @@ func (s *Scope) buildStructLike(cu *CodeUtils, v *parser.StructLike, usedName ..
 	// reserve method names
 	for _, f := range v.Fields {
 		fn := s.identify(cu, f.Name)
-		if fn == "" {
-			// Since the variable name is empty, the type name needs to be used when retrieving the value.
+		if cu.Features().EnableNestedStruct {
+			// EnableNestedStruct, the type name needs to be used when retrieving the value.
 			fn = s.identify(cu, f.Type.Name)
 			if strings.Contains(fn, ".") {
 				fns := strings.Split(fn, ".")
 				fn = fns[len(fns)-1]
 			}
 		}
+
 		st.scope.Add("Get"+fn, _p("get:"+f.Name))
 		if cu.Features().GenerateSetter {
 			st.scope.Add("Set"+fn, _p("set:"+f.Name))
@@ -353,11 +348,13 @@ func (s *Scope) buildStructLike(cu *CodeUtils, v *parser.StructLike, usedName ..
 	// field names
 	for _, f := range v.Fields {
 		fn := s.identify(cu, f.Name)
-		fn = st.scope.Add(fn, f.Name)
 		isNested := false
-		if fn == "" {
+		if cu.Features().EnableNestedStruct && strings.EqualFold(f.Type.Name, f.Name) {
+			// EnableNestedStruct, the file name needs to be ""
+			fn = ""
 			isNested = true
 		}
+		fn = st.scope.Add(fn, f.Name)
 		id := id2str(f.ID)
 		st.fields = append(st.fields, &Field{
 			Field:     f,
@@ -420,8 +417,8 @@ func (s *Scope) resolveTypesAndValues(cu *CodeUtils) {
 	for f := range ff {
 		v := f.Field
 		f.typeName = ensureType(resolver.ResolveFieldTypeName(v))
-		// Since the variable name is empty, the type name needs to be used when retrieving the value.
-		if cu.Features().EnableNestedStruct && f.GetName() == "_" {
+		// EnableNestedStruct, the type name needs to be used when retrieving the value.
+		if cu.Features().EnableNestedStruct && strings.EqualFold(f.Type.Name, f.Name) {
 			name := f.typeName.Deref().String()
 			if strings.Contains(name, ".") {
 				names := strings.Split(name, ".")

--- a/generator/golang/scope_internal.go
+++ b/generator/golang/scope_internal.go
@@ -322,7 +322,7 @@ func (s *Scope) buildStructLike(cu *CodeUtils, v *parser.StructLike, usedName ..
 	for _, f := range v.Fields {
 		fn := s.identify(cu, f.Name)
 		if cu.Features().EnableNestedStruct && isNestedField(f.Type.Name, f.Name) {
-			// EnableNestedStruct, the type name needs to be used when retrieving the value.
+			// EnableNestedStruct, the type name needs to be used when retrieving the value for getter&setter
 			fn = s.identify(cu, f.Type.Name)
 			if strings.Contains(fn, ".") {
 				fns := strings.Split(fn, ".")
@@ -350,8 +350,6 @@ func (s *Scope) buildStructLike(cu *CodeUtils, v *parser.StructLike, usedName ..
 		fn := s.identify(cu, f.Name)
 		isNested := false
 		if cu.Features().EnableNestedStruct && isNestedField(f.Type.Name, f.Name) {
-			// EnableNestedStruct, the file name needs to be ""
-			fn = ""
 			isNested = true
 		}
 		fn = st.scope.Add(fn, f.Name)
@@ -417,7 +415,10 @@ func (s *Scope) resolveTypesAndValues(cu *CodeUtils) {
 	for f := range ff {
 		v := f.Field
 		f.typeName = ensureType(resolver.ResolveFieldTypeName(v))
-		// EnableNestedStruct, the type name needs to be used when retrieving the value.
+		// This is used to set the real field name for nested struct, ex.
+		// type T struct {
+		// 	*Nested
+		// }
 		if cu.Features().EnableNestedStruct && isNestedField(f.Type.Name, f.Name) {
 			name := f.typeName.Deref().String()
 			if strings.Contains(name, ".") {

--- a/generator/golang/scope_internal.go
+++ b/generator/golang/scope_internal.go
@@ -349,7 +349,7 @@ func (s *Scope) buildStructLike(cu *CodeUtils, v *parser.StructLike, usedName ..
 	for _, f := range v.Fields {
 		fn := s.identify(cu, f.Name)
 		isNested := false
-		if cu.Features().EnableNestedStruct && strings.EqualFold(f.Type.Name, f.Name) {
+		if cu.Features().EnableNestedStruct && isNestedField(f.Type.Name, f.Name) {
 			// EnableNestedStruct, the file name needs to be ""
 			fn = ""
 			isNested = true
@@ -418,7 +418,7 @@ func (s *Scope) resolveTypesAndValues(cu *CodeUtils) {
 		v := f.Field
 		f.typeName = ensureType(resolver.ResolveFieldTypeName(v))
 		// EnableNestedStruct, the type name needs to be used when retrieving the value.
-		if cu.Features().EnableNestedStruct && strings.EqualFold(f.Type.Name, f.Name) {
+		if cu.Features().EnableNestedStruct && isNestedField(f.Type.Name, f.Name) {
 			name := f.typeName.Deref().String()
 			if strings.Contains(name, ".") {
 				names := strings.Split(name, ".")
@@ -474,4 +474,14 @@ func (s *Scope) resolveTypesAndValues(cu *CodeUtils) {
 			}
 		}
 	}
+}
+
+func isNestedField(typeName, fieldName string) bool {
+	tmp := strings.Split(typeName, ".")
+	typeName = tmp[len(tmp)-1]
+	if strings.EqualFold(typeName, fieldName) {
+		return true
+	}
+
+	return false
 }

--- a/generator/golang/scope_internal.go
+++ b/generator/golang/scope_internal.go
@@ -321,12 +321,12 @@ func (s *Scope) buildStructLike(cu *CodeUtils, v *parser.StructLike, usedName ..
 	// reserve method names
 	for _, f := range v.Fields {
 		fn := s.identify(cu, f.Name)
-		if cu.Features().EnableNestedStruct {
+		if cu.Features().EnableNestedStruct && isNestedField(f.Type.Name, f.Name) {
 			// EnableNestedStruct, the type name needs to be used when retrieving the value.
 			fn = s.identify(cu, f.Type.Name)
 			if strings.Contains(fn, ".") {
 				fns := strings.Split(fn, ".")
-				fn = fns[len(fns)-1]
+				fn = s.identify(cu, fns[len(fns)-1])
 			}
 		}
 

--- a/generator/golang/scope_internal.go
+++ b/generator/golang/scope_internal.go
@@ -330,6 +330,10 @@ func (s *Scope) buildStructLike(cu *CodeUtils, v *parser.StructLike, usedName ..
 		if fn == "" {
 			// Since the variable name is empty, the type name needs to be used when retrieving the value.
 			fn = s.identify(cu, f.Type.Name)
+			if strings.Contains(fn, ".") {
+				fns := strings.Split(fn, ".")
+				fn = fns[len(fns)-1]
+			}
 		}
 		st.scope.Add("Get"+fn, _p("get:"+f.Name))
 		if cu.Features().GenerateSetter {
@@ -418,7 +422,12 @@ func (s *Scope) resolveTypesAndValues(cu *CodeUtils) {
 		f.typeName = ensureType(resolver.ResolveFieldTypeName(v))
 		// Since the variable name is empty, the type name needs to be used when retrieving the value.
 		if cu.Features().EnableNestedStruct && f.GetName() == "_" {
-			f.name = Name(f.typeName.Deref().String())
+			name := f.typeName.Deref().String()
+			if strings.Contains(name, ".") {
+				names := strings.Split(name, ".")
+				name = names[len(names)-1]
+			}
+			f.name = Name(name)
 		}
 		f.frugalTypeName = ensureType(frugalResolver.ResolveFrugalTypeName(v.Type))
 		f.defaultTypeName = ensureType(resolver.GetDefaultValueTypeName(v))

--- a/generator/golang/templates/slim/slim.go
+++ b/generator/golang/templates/slim/slim.go
@@ -38,7 +38,11 @@ type {{$TypeName}} struct {
 	{{- if and Features.ReserveComments .ReservedComments}}
 	{{.ReservedComments}}
 	{{- end}}
-	{{(.GoName)}} {{.GoTypeName}} {{GenFieldTags . (InsertionPoint $.Category $.Name .Name "tag")}} 
+	{{- if .IsNested}}
+		{{.GoTypeName}} {{GenFieldTags . (InsertionPoint $.Category $.Name .Name "tag")}}
+	{{else}}
+		{{(.GoName)}} {{.GoTypeName}} {{GenFieldTags . (InsertionPoint $.Category $.Name .Name "tag")}}
+	{{- end}}
 {{- end}}
 	{{- if Features.KeepUnknownFields}}
 	{{- UseStdLibrary "unknown"}}

--- a/generator/golang/util.go
+++ b/generator/golang/util.go
@@ -116,10 +116,6 @@ func (cu *CodeUtils) Template() string {
 	return cu.useTemplate
 }
 
-func (cu *CodeUtils) SetTemplate(tmpl string) {
-	cu.useTemplate = tmpl
-}
-
 // UseTemplate specifies a different template to generate codes.
 func (cu *CodeUtils) UseTemplate(value string) error {
 	if value != defaultTemplate && cu.alternative[value] == nil {

--- a/generator/golang/util.go
+++ b/generator/golang/util.go
@@ -116,6 +116,10 @@ func (cu *CodeUtils) Template() string {
 	return cu.useTemplate
 }
 
+func (cu *CodeUtils) SetTemplate(tmpl string) {
+	cu.useTemplate = tmpl
+}
+
 // UseTemplate specifies a different template to generate codes.
 func (cu *CodeUtils) UseTemplate(value string) error {
 	if value != defaultTemplate && cu.alternative[value] == nil {


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
slim 模板下支持生成嵌套接口体，使用方法如下：
IDL
```
struct HelloReq {}

struct HelloResp {
    1: HelloReq FFF (thrift.nested="true");
    2: test.HelloReq222 TTT (thrift.nested="true");
}
```
命令
```
thriftgo -r  -g go:enable_nested_struct,template=slim test.thrift
```
生成代码
```
type HelloResp struct {
	*HelloReq `thrift:"HelloReq,1" json:"FFF"`
	*example2.HelloReq222 `thrift:"HelloReq222,2" json:"TTT"`
}
```
兼容性:
单独加了选项控制生产内容，不影响整体的代码生成


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


## Related Issue
<!-- use words like 'fix #123', 'closes #123' -->
