### PR TITLE
feat: Support Nil_Safe in Setter

### DIFF
--- a/generator/golang/templates/struct.go
+++ b/generator/golang/templates/struct.go
@@ -405,10 +405,20 @@ func (p *{{$TypeName}}) {{$GetterName}}() (v {{$FieldTypeName}}) {
 {{- $SetterName := .Setter}}
 {{- if .IsResponseFieldOfResult}}
 func (p *{{$TypeName}}) {{$SetterName}}(x interface{}) {
+	{{- if Features.NilSafe}}
+	if p == nil {
+		return
+	}
+	{{- end}}
     p.{{$FieldName}} = x.({{$FieldTypeName}})
 }
 {{- else}}
 func (p *{{$TypeName}}) {{$SetterName}}(val {{$FieldTypeName}}) {
+	{{- if Features.NilSafe}}
+	if p == nil {
+		return
+	}
+	{{- end}}
 	p.{{$FieldName}} = val
 }
 {{- end}}


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

1. Support `Nil_Safe` in setter function.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

It will be helpful when we use the ` a.GetB().GetC().Set(d)` under the `nil_safe` mode.

## Related Issue
<!-- use words like 'fix #123', 'closes #123' -->
