### PR TITLE
fix: slim template should generate InitDefault for frugal

### DIFF
--- a/generator/golang/templates/slim/slim.go
+++ b/generator/golang/templates/slim/slim.go
@@ -59,6 +59,12 @@ func New{{$TypeName}}() *{{$TypeName}} {
 	}
 }
 
+func (p *{{$TypeName}}) InitDefault() {
+	*p = {{$TypeName}}{
+		{{template "StructLikeDefault" .}}
+	}
+}
+
 {{template "FieldGetOrSet" .}}
 
 {{if eq .Category "union"}}


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
For slim template, an `InitDefault` method should be generated for frugal.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
According to thrift encoding behavior, if an optional field is set to its default value, it's not encoded to the output.

Frugal will call `InitDefault()` for types implemented this method to set default values on optional fields.

Without this, if an optional field is not found in the wire thrift binary, it will be set to the type's zero value instead of default value defined in the IDL.


<!--- If it fixes an open issue, please link to the issue here. -->


## Related Issue
<!-- use words like 'fix #123', 'closes #123' -->
