### PR TITLE
fix: only generate InitDefault when FrugalTag is on

### DIFF
--- a/generator/golang/templates/slim/slim.go
+++ b/generator/golang/templates/slim/slim.go
@@ -59,11 +59,13 @@ func New{{$TypeName}}() *{{$TypeName}} {
 	}
 }
 
+{{if Features.FrugalTag}}
 func (p *{{$TypeName}}) InitDefault() {
 	*p = {{$TypeName}}{
 		{{template "StructLikeDefault" .}}
 	}
 }
+{{end}}{{/* if Features.FrugalTag */}}
 
 {{template "FieldGetOrSet" .}}
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
In https://github.com/cloudwego/thriftgo/pull/115, we will generate `InitDefault` in slim template, but it's only useful in frugal, so we only add it when FrugalTag is on.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


## Related Issue
<!-- use words like 'fix #123', 'closes #123' -->
