### PR TITLE
fix: fix dead loop when typedefs has cycle

### DIFF
--- a/semantic/semantic.go
+++ b/semantic/semantic.go
@@ -453,6 +453,7 @@ func (r *resolver) ResolveTypedefs() error {
 			return fmt.Errorf("typedefs can not be resolved: %s", strings.Join(ss, ", "))
 		}
 		tds = tmp
+		cnt = len(tds)
 	}
 	return nil
 }


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
fix dead loop when typedefs has cycyle
Try this following IDL:
```
namespace go a.b.c

struct A{

}

struct B{

}

struct C{

}

typedef B M
typedef M N
typedef N NN
typedef BB BB
typedef A AA
```

Before this pr, thriftgo will run into a dead loop.
After this pr, thriftgo can correctly check 'typedef BB BB' is illegal and jump out of the dead loop.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


## Related Issue
<!-- use words like 'fix #123', 'closes #123' -->
