### PR TITLE
feat: add @preserve comments to preserve the struct from being trimmed

### DIFF
--- a/tool/trimmer/main.go
+++ b/tool/trimmer/main.go
@@ -16,16 +16,16 @@ package main
 
 import (
 	"fmt"
-	"github.com/cloudwego/thriftgo/parser"
-	"github.com/cloudwego/thriftgo/semantic"
-	"github.com/cloudwego/thriftgo/tool/trimmer/dump"
-	"github.com/cloudwego/thriftgo/tool/trimmer/trim"
-	"github.com/cloudwego/thriftgo/version"
 	"os"
 	"path/filepath"
 	"strings"
 
 	"github.com/cloudwego/thriftgo/generator"
+	"github.com/cloudwego/thriftgo/parser"
+	"github.com/cloudwego/thriftgo/semantic"
+	"github.com/cloudwego/thriftgo/tool/trimmer/dump"
+	"github.com/cloudwego/thriftgo/tool/trimmer/trim"
+	"github.com/cloudwego/thriftgo/version"
 )
 
 var (
@@ -120,7 +120,7 @@ func main() {
 	os.Exit(0)
 }
 
-func recurseDump(ast *parser.Thrift, sourceDir string, outDir string) {
+func recurseDump(ast *parser.Thrift, sourceDir, outDir string) {
 	if ast == nil {
 		return
 	}

--- a/tool/trimmer/main.go
+++ b/tool/trimmer/main.go
@@ -16,15 +16,14 @@ package main
 
 import (
 	"fmt"
-	"os"
-	"path/filepath"
-	"strings"
-
 	"github.com/cloudwego/thriftgo/parser"
 	"github.com/cloudwego/thriftgo/semantic"
 	"github.com/cloudwego/thriftgo/tool/trimmer/dump"
 	"github.com/cloudwego/thriftgo/tool/trimmer/trim"
 	"github.com/cloudwego/thriftgo/version"
+	"os"
+	"path/filepath"
+	"strings"
 
 	"github.com/cloudwego/thriftgo/generator"
 )
@@ -99,7 +98,7 @@ func main() {
 					os.Exit(2)
 				}
 			} else {
-				println("-o should be set as a valid dir to enable -r", err.Error())
+				println("-o should be set as a valid dir to enable -r")
 				os.Exit(2)
 			}
 		}
@@ -121,7 +120,7 @@ func main() {
 	os.Exit(0)
 }
 
-func recurseDump(ast *parser.Thrift, sourceDir, outDir string) {
+func recurseDump(ast *parser.Thrift, sourceDir string, outDir string) {
 	if ast == nil {
 		return
 	}

--- a/tool/trimmer/test_cases/sample1.thrift
+++ b/tool/trimmer/test_cases/sample1.thrift
@@ -53,6 +53,7 @@ enum Gender {
     FEMALE (key = "1", key = "2", key2 = "v2")
 } (a = "b")
 
+#@PRESERvE
 struct Address {
     1: required string(key = "v") street
     2: required string city

--- a/tool/trimmer/test_cases/tests/example2.thrift
+++ b/tool/trimmer/test_cases/tests/example2.thrift
@@ -22,6 +22,6 @@ struct E{
 
 }
 
-service MyService{
+service MyService extends sample1.EmployeeService{
     string A(1:required E req,2:required test.TestStruct t)
 }

--- a/tool/trimmer/trim/mark.go
+++ b/tool/trimmer/trim/mark.go
@@ -174,7 +174,7 @@ func (t *Trimmer) markTypeDef(theType *parser.Type, ast *parser.Thrift, filename
 }
 
 // for -m, trace the extends and find specified method to base on
-func (t *Trimmer) traceExtendMethod(father *parser.Service, svc *parser.Service, ast *parser.Thrift, filename string) (ret bool) {
+func (t *Trimmer) traceExtendMethod(father, svc *parser.Service, ast *parser.Thrift, filename string) (ret bool) {
 	for _, function := range svc.Functions {
 		funcName := father.Name + "." + function.Name
 		for i, method := range t.trimMethods {

--- a/tool/trimmer/trim/traversal.go
+++ b/tool/trimmer/trim/traversal.go
@@ -14,7 +14,11 @@
 
 package trim
 
-import "github.com/cloudwego/thriftgo/parser"
+import (
+	"github.com/cloudwego/thriftgo/parser"
+	"regexp"
+	"strings"
+)
 
 // traverse and remove the unmarked part of ast
 func (t *Trimmer) traversal(ast *parser.Thrift, filename string) {
@@ -30,7 +34,7 @@ func (t *Trimmer) traversal(ast *parser.Thrift, filename string) {
 
 	var listStruct []*parser.StructLike
 	for i := range ast.Structs {
-		if t.marks[filename][ast.Structs[i]] {
+		if t.marks[filename][ast.Structs[i]] || checkPreserve(ast.Structs[i]) {
 			listStruct = append(listStruct, ast.Structs[i])
 		}
 	}
@@ -68,4 +72,11 @@ func (t *Trimmer) traversal(ast *parser.Thrift, filename string) {
 		}
 	}
 	ast.Services = listService
+
+}
+
+func checkPreserve(theStruct *parser.StructLike) bool {
+	pattern := `^[\s]*(\/\/|#)[\s]*@preserve[\s]*$`
+	regex := regexp.MustCompile(pattern)
+	return regex.MatchString(strings.ToLower(theStruct.ReservedComments))
 }

--- a/tool/trimmer/trim/traversal.go
+++ b/tool/trimmer/trim/traversal.go
@@ -15,9 +15,10 @@
 package trim
 
 import (
-	"github.com/cloudwego/thriftgo/parser"
 	"regexp"
 	"strings"
+
+	"github.com/cloudwego/thriftgo/parser"
 )
 
 // traverse and remove the unmarked part of ast
@@ -72,7 +73,6 @@ func (t *Trimmer) traversal(ast *parser.Thrift, filename string) {
 		}
 	}
 	ast.Services = listService
-
 }
 
 func checkPreserve(theStruct *parser.StructLike) bool {


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
for IDL trimmer, add a way to use comments "@preserve" to preserve struct-likes from being trimmed.
fix some bugs for trimmer tool.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
users need a way to avoid struct-likes being trimmed for a direct-use of the thrift-gen code, other than using them for rpc. marking @preserve in comments can be an easy way to stop trimmer from deleting the structs.
