### PR TITLE
fix: fix @preserve comment bug

### DIFF
--- a/generator/golang/backend.go
+++ b/generator/golang/backend.go
@@ -86,7 +86,7 @@ func (g *GoBackend) Generate(req *plugin.Request, log backend.LogFunc) *plugin.R
 	g.log = log
 	g.prepareUtilities()
 	if g.utils.Features().TrimIDL {
-		err := trim.TrimAST(req.AST, nil)
+		err := trim.TrimAST(req.AST, nil, false)
 		if err != nil {
 			g.log.Warn("trim error:", err.Error())
 		}

--- a/tool/trimmer/args.go
+++ b/tool/trimmer/args.go
@@ -45,7 +45,7 @@ type Arguments struct {
 	IDL        string
 	Recurse    string
 	Methods    StringSlice
-	Force      bool
+	Preserve   string
 }
 
 // BuildFlags initializes command line flags.
@@ -63,8 +63,8 @@ func (a *Arguments) BuildFlags() *flag.FlagSet {
 	f.Var(&a.Methods, "m", "")
 	f.Var(&a.Methods, "method", "")
 
-	f.BoolVar(&a.Force, "f", false, "")
-	f.BoolVar(&a.Force, "force", false, "")
+	f.StringVar(&a.Preserve, "p", "true", "")
+	f.StringVar(&a.Preserve, "preserve", "true", "")
 
 	f.Usage = help
 	return f
@@ -99,7 +99,7 @@ Options:
   -o, --out	[file/dir]	Specify the output IDL file/dir.
   -r, --recurse	[dir]		Specify a root dir and dump the included IDL recursively beneath the given root. -o should be set as a directory.
   -m, --method [service.method] Only keep the specified methods and their dependents. Accept multiple -m.
-  -f, --force	use force trimming, ignore @preserve comments
+  -p, --preserve [true/false]	Set to false to ignore @preserve comments
 `)
 	// print backend options
 	for _, b := range g.AllBackend() {

--- a/tool/trimmer/args.go
+++ b/tool/trimmer/args.go
@@ -45,6 +45,7 @@ type Arguments struct {
 	IDL        string
 	Recurse    string
 	Methods    StringSlice
+	Force      bool
 }
 
 // BuildFlags initializes command line flags.
@@ -61,6 +62,9 @@ func (a *Arguments) BuildFlags() *flag.FlagSet {
 
 	f.Var(&a.Methods, "m", "")
 	f.Var(&a.Methods, "method", "")
+
+	f.BoolVar(&a.Force, "f", false, "")
+	f.BoolVar(&a.Force, "force", false, "")
 
 	f.Usage = help
 	return f
@@ -95,6 +99,7 @@ Options:
   -o, --out	[file/dir]	Specify the output IDL file/dir.
   -r, --recurse	[dir]		Specify a root dir and dump the included IDL recursively beneath the given root. -o should be set as a directory.
   -m, --method [service.method] Only keep the specified methods and their dependents. Accept multiple -m.
+  -f, --force	use force trimming, ignore @preserve comments
 `)
 	// print backend options
 	for _, b := range g.AllBackend() {

--- a/tool/trimmer/dirTree.go
+++ b/tool/trimmer/dirTree.go
@@ -15,6 +15,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -87,8 +88,8 @@ func isDirectoryEmpty(path string) (bool, error) {
 		return false, nil
 	}
 
-	if len(err.Error()) > len("EOF") {
-		return false, err
+	if errors.Is(err, os.ErrNotExist) {
+		return true, nil
 	}
-	return true, nil
+	return false, err
 }

--- a/tool/trimmer/main.go
+++ b/tool/trimmer/main.go
@@ -64,7 +64,7 @@ func main() {
 	check(semantic.ResolveSymbols(ast))
 
 	// trim ast
-	check(trim.TrimAST(ast, a.Methods))
+	check(trim.TrimAST(ast, a.Methods, a.Force))
 
 	// dump the trimmed ast to idl
 	idl, err := dump.DumpIDL(ast)

--- a/tool/trimmer/main.go
+++ b/tool/trimmer/main.go
@@ -52,6 +52,16 @@ func main() {
 		os.Exit(0)
 	}
 
+	preserve := true
+	if a.Preserve != "true" && a.Preserve != "false" {
+		help()
+		os.Exit(2)
+	} else {
+		if a.Preserve == "false" {
+			preserve = false
+		}
+	}
+
 	// parse file to ast
 	ast, err := parser.ParseFile(a.IDL, nil, true)
 	check(err)
@@ -64,7 +74,7 @@ func main() {
 	check(semantic.ResolveSymbols(ast))
 
 	// trim ast
-	check(trim.TrimAST(ast, a.Methods, a.Force))
+	check(trim.TrimAST(ast, a.Methods, !preserve))
 
 	// dump the trimmed ast to idl
 	idl, err := dump.DumpIDL(ast)

--- a/tool/trimmer/main.go
+++ b/tool/trimmer/main.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 
 	"github.com/cloudwego/thriftgo/generator"
@@ -53,12 +54,11 @@ func main() {
 	}
 
 	preserve := true
-	if a.Preserve != "true" && a.Preserve != "false" {
-		help()
-		os.Exit(2)
-	} else {
-		if a.Preserve == "false" {
-			preserve = false
+	if a.Preserve != "" {
+		preserve, err = strconv.ParseBool(a.Preserve)
+		if err != nil {
+			help()
+			os.Exit(2)
 		}
 	}
 

--- a/tool/trimmer/test_cases/sample1.thrift
+++ b/tool/trimmer/test_cases/sample1.thrift
@@ -53,7 +53,6 @@ enum Gender {
     FEMALE (key = "1", key = "2", key2 = "v2")
 } (a = "b")
 
-#@PRESERvE
 struct Address {
     1: required string(key = "v") street
     2: required string city
@@ -61,6 +60,7 @@ struct Address {
     4: required a country
 }
 
+// @pResErve
 struct Company {
     1: required string name
     2: optional Address address

--- a/tool/trimmer/trim/mark.go
+++ b/tool/trimmer/trim/mark.go
@@ -15,8 +15,9 @@
 package trim
 
 import (
-	"github.com/cloudwego/thriftgo/parser"
 	"strings"
+
+	"github.com/cloudwego/thriftgo/parser"
 )
 
 // mark the used part of ast

--- a/tool/trimmer/trim/mark.go
+++ b/tool/trimmer/trim/mark.go
@@ -174,7 +174,7 @@ func (t *Trimmer) markTypeDef(theType *parser.Type, ast *parser.Thrift, filename
 }
 
 // for -m, trace the extends and find specified method to base on
-func (t *Trimmer) traceExtendMethod(father, svc *parser.Service, ast *parser.Thrift, filename string) (ret bool) {
+func (t *Trimmer) traceExtendMethod(father *parser.Service, svc *parser.Service, ast *parser.Thrift, filename string) (ret bool) {
 	for _, function := range svc.Functions {
 		funcName := father.Name + "." + function.Name
 		for i, method := range t.trimMethods {

--- a/tool/trimmer/trim/mark.go
+++ b/tool/trimmer/trim/mark.go
@@ -174,7 +174,7 @@ func (t *Trimmer) markTypeDef(theType *parser.Type, ast *parser.Thrift, filename
 }
 
 // for -m, trace the extends and find specified method to base on
-func (t *Trimmer) traceExtendMethod(father *parser.Service, svc *parser.Service, ast *parser.Thrift, filename string) (ret bool) {
+func (t *Trimmer) traceExtendMethod(father, svc *parser.Service, ast *parser.Thrift, filename string) (ret bool) {
 	for _, function := range svc.Functions {
 		funcName := father.Name + "." + function.Name
 		for i, method := range t.trimMethods {

--- a/tool/trimmer/trim/traversal.go
+++ b/tool/trimmer/trim/traversal.go
@@ -15,9 +15,6 @@
 package trim
 
 import (
-	"regexp"
-	"strings"
-
 	"github.com/cloudwego/thriftgo/parser"
 )
 
@@ -35,7 +32,7 @@ func (t *Trimmer) traversal(ast *parser.Thrift, filename string) {
 
 	var listStruct []*parser.StructLike
 	for i := range ast.Structs {
-		if t.marks[filename][ast.Structs[i]] || checkPreserve(ast.Structs[i]) {
+		if t.marks[filename][ast.Structs[i]] || t.checkPreserve(ast.Structs[i]) {
 			listStruct = append(listStruct, ast.Structs[i])
 		}
 	}
@@ -73,10 +70,4 @@ func (t *Trimmer) traversal(ast *parser.Thrift, filename string) {
 		}
 	}
 	ast.Services = listService
-}
-
-func checkPreserve(theStruct *parser.StructLike) bool {
-	pattern := `^[\s]*(\/\/|#)[\s]*@preserve[\s]*$`
-	regex := regexp.MustCompile(pattern)
-	return regex.MatchString(strings.ToLower(theStruct.ReservedComments))
 }


### PR DESCRIPTION
## Description
fix #124 @preserve comment bug for includes of preserved structs.
add -p or -preserve to optional ignore @preserve comments

## Motivation and Context
to fix bug of #124
add a way to ignore @preserve comments

## Related Issue
fix #124 
