### PR TITLE
Fix: fix dir tree traversal bug

### DIFF
--- a/tool/trimmer/dirTree.go
+++ b/tool/trimmer/dirTree.go
@@ -47,7 +47,7 @@ func createDirTree(sourceDir, destinationDir string) {
 
 // remove empty directory of output dir-tree
 func removeEmptyDir(source string) {
-	files, err := os.ReadDir(source) //读取目录下文件
+	files, err := os.ReadDir(source)
 	if err != nil {
 		return
 	}
@@ -57,10 +57,7 @@ func removeEmptyDir(source string) {
 		}
 	}
 	empty, err := isDirectoryEmpty(source)
-	if err != nil {
-		println(err.Error())
-	}
-	if empty {
+	if empty || err != nil {
 		_ = os.RemoveAll(source)
 	}
 }

--- a/tool/trimmer/dirTree_test.go
+++ b/tool/trimmer/dirTree_test.go
@@ -4,13 +4,14 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//	http://www.apache.org/licenses/LICENSE-2.0
+//   http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 package main
 
 import (

--- a/tool/trimmer/dirTree_test.go
+++ b/tool/trimmer/dirTree_test.go
@@ -1,3 +1,16 @@
+// Copyright 2023 CloudWeGo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 package main
 
 import (

--- a/tool/trimmer/dirTree_test.go
+++ b/tool/trimmer/dirTree_test.go
@@ -15,10 +15,11 @@
 package main
 
 import (
-	"github.com/cloudwego/thriftgo/pkg/test"
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/cloudwego/thriftgo/pkg/test"
 )
 
 func TestDirTree(t *testing.T) {

--- a/tool/trimmer/dirTree_test.go
+++ b/tool/trimmer/dirTree_test.go
@@ -1,0 +1,43 @@
+package main
+
+import (
+	"github.com/cloudwego/thriftgo/pkg/test"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestDirTree(t *testing.T) {
+	_ = os.RemoveAll("trimmer_test")
+	createDirTree("test_cases", "trimmer_test")
+	fileCount, dirCount, err := countFilesAndSubdirectories("trimmer_test")
+	test.Assert(t, err == nil)
+	test.Assert(t, fileCount == 0)
+	test.Assert(t, dirCount == 3)
+	removeEmptyDir("trimmer_test")
+	_, err = os.ReadDir("trimmer_test")
+	test.Assert(t, err != nil)
+}
+
+func countFilesAndSubdirectories(dirPath string) (int, int, error) {
+	var fileCount, dirCount int
+	files, err := os.ReadDir(dirPath)
+	if err != nil {
+		return 0, 0, err
+	}
+	for _, file := range files {
+		if file.IsDir() {
+			dirCount++
+			subDirPath := filepath.Join(dirPath, file.Name())
+			subFileCount, subDirCount, err := countFilesAndSubdirectories(subDirPath)
+			if err != nil {
+				return 0, 0, err
+			}
+			fileCount += subFileCount
+			dirCount += subDirCount
+		} else {
+			fileCount++
+		}
+	}
+	return fileCount, dirCount, nil
+}

--- a/tool/trimmer/main.go
+++ b/tool/trimmer/main.go
@@ -112,6 +112,11 @@ func main() {
 				os.Exit(2)
 			}
 		}
+		relPath, err := filepath.Rel(a.Recurse, a.OutputFile)
+		if err == nil && (len(relPath) < 2 || relPath[:2] != "..") {
+			println("output-dir should be set outside of -r base-dir to avoid overlay")
+			os.Exit(2)
+		}
 		createDirTree(a.Recurse, a.OutputFile)
 		recurseDump(ast, a.Recurse, a.OutputFile)
 		relativePath, err := filepath.Rel(a.Recurse, a.IDL)

--- a/tool/trimmer/test_cases/tests/dir/dir2/test.thrift
+++ b/tool/trimmer/test_cases/tests/dir/dir2/test.thrift
@@ -1,0 +1,20 @@
+// Copyright 2023 CloudWeGo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+include "../../../sample1.thrift"
+
+// @preserve
+struct TestStruct{
+    1: sample1.Person person
+}

--- a/tool/trimmer/trim/trimmer_test.go
+++ b/tool/trimmer/trim/trimmer_test.go
@@ -25,12 +25,12 @@ import (
 )
 
 func TestTrimmer(t *testing.T) {
-	t.Run("trim AST-case 1", testCase1)
+	t.Run("trim AST", testSingleFile)
 	// t.Run("trim AST - test many", testMany)
 }
 
 // test single file ast trimming
-func testCase1(t *testing.T) {
+func testSingleFile(t *testing.T) {
 	trimmer, err := newTrimmer(nil, "")
 	test.Assert(t, err == nil, err)
 	filename := filepath.Join("..", "test_cases", "sample1.thrift")


### PR DESCRIPTION
## Description
fix dir-tree copy error for trimmer tool
add limitation to -o when -r is in used for trimmer tool

## Motivation and Context
using recursive trim may encounter some problems with relative path
restriction should be added to output dir to stop output inside the specified -r root-dir which may overlay the original IDL