### PR TITLE
fix: fix no throw generated when function resp is void

### DIFF
--- a/generator/golang/templates/client.go
+++ b/generator/golang/templates/client.go
@@ -86,6 +86,15 @@ func (p *{{$ClientName}}) {{- template "FunctionSignature" . -}} {
 	if err = p.Client_().Call(ctx, "{{.Name}}", &_args, &_result); err != nil {
 		return
 	}
+	{{- if .Throws}}
+	switch {
+	{{- range .Throws}}
+	case _result.{{($ResType.Field .Name).GoName}} != nil:
+		return _result.{{($ResType.Field .Name).GoName}}
+	{{- end}}
+	}
+	{{- end}}
+
 	{{- end}}
 	return nil
 	{{- else}}{{/* If .Void */}}


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


## Related Issue
<!-- use words like 'fix #123', 'closes #123' -->
#126 