### PR TITLE
fix: fix include semantic check for trimmer

### DIFF
--- a/tool/trimmer/dirTree_test.go
+++ b/tool/trimmer/dirTree_test.go
@@ -28,7 +28,7 @@ func TestDirTree(t *testing.T) {
 	fileCount, dirCount, err := countFilesAndSubdirectories("trimmer_test")
 	test.Assert(t, err == nil)
 	test.Assert(t, fileCount == 0)
-	test.Assert(t, dirCount == 3)
+	test.Assert(t, dirCount == 4)
 	removeEmptyDir("trimmer_test")
 	_, err = os.ReadDir("trimmer_test")
 	test.Assert(t, err != nil)

--- a/tool/trimmer/test_cases/test_include/example.thrift
+++ b/tool/trimmer/test_cases/test_include/example.thrift
@@ -1,0 +1,24 @@
+// Copyright 2023 CloudWeGo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+
+namespace go a
+
+include "test.thrift"
+
+struct E{
+    1: required test.TestStruct a
+}
+
+

--- a/tool/trimmer/test_cases/test_include/test.thrift
+++ b/tool/trimmer/test_cases/test_include/test.thrift
@@ -1,0 +1,26 @@
+// Copyright 2023 CloudWeGo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace go c
+
+struct TestStruct{
+    // hello
+    1:required string hello
+    2:required string id
+}
+
+enum GenderEnum{
+    MALE
+    FEMALE
+}

--- a/tool/trimmer/trim/traversal.go
+++ b/tool/trimmer/trim/traversal.go
@@ -71,4 +71,7 @@ func (t *Trimmer) traversal(ast *parser.Thrift, filename string) {
 	}
 	ast.Services = listService
 	ast.Name2Category = nil
+	for _, inc := range ast.Includes {
+		inc.Used = nil
+	}
 }

--- a/tool/trimmer/trim/trimmer.go
+++ b/tool/trimmer/trim/trimmer.go
@@ -61,7 +61,6 @@ func TrimAST(ast *parser.Thrift, trimMethods []string, forceTrimming bool) error
 	}
 	trimmer.markAST(ast)
 	trimmer.traversal(ast, ast.Filename)
-	ast.Name2Category = nil
 	if path := parser.CircleDetect(ast); len(path) > 0 {
 		check(fmt.Errorf("found include circle:\n\t%s", path))
 	}


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
fix unused include when trimming idl

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


## Related Issue
<!-- use words like 'fix #123', 'closes #123' -->
