### PR TITLE
chore: expand @preserve regexp for trimmer

### DIFF
--- a/tool/trimmer/test_cases/sample1.thrift
+++ b/tool/trimmer/test_cases/sample1.thrift
@@ -100,6 +100,13 @@ struct Simple { // should not appear
 struct MaybeUseless{
 }
 
+// some comments
+# @preServe
+// some others
+struct preserved{
+
+}
+
 service EmployeeService extends sample1b.GetPerson {
     Employee getEmployee(1: string id)
     void addEmployee(1: Employee employee)

--- a/tool/trimmer/trim/trimmer.go
+++ b/tool/trimmer/trim/trimmer.go
@@ -113,7 +113,7 @@ func newTrimmer(files []string, outDir string) (*Trimmer, error) {
 	}
 	trimmer.asts = make(map[string]*parser.Thrift)
 	trimmer.marks = make(map[string]map[interface{}]bool)
-	pattern := `^[\s]*(\/\/|#)[\s]*@preserve[\s]*$`
+	pattern := `(?m)^[\s]*(\/\/|#)[\s]*@preserve[\s]*$`
 	trimmer.preserveRegex = regexp.MustCompile(pattern)
 	return trimmer, nil
 }

--- a/tool/trimmer/trim/trimmer_test.go
+++ b/tool/trimmer/trim/trimmer_test.go
@@ -47,7 +47,7 @@ func testSingleFile(t *testing.T) {
 	trimmer.markAST(ast)
 	trimmer.traversal(ast, ast.Filename)
 
-	test.Assert(t, len(ast.Structs) == 6)
+	test.Assert(t, len(ast.Structs) == 7)
 	test.Assert(t, len(ast.Includes) == 1)
 	test.Assert(t, len(ast.Typedefs) == 5)
 	test.Assert(t, len(ast.Namespaces) == 1)


### PR DESCRIPTION
## Description
edit @preserve regexp for trimmer to match multi-line comments

## Motivation and Context
loosen match restrictions for @preserve comments for trimmer tools