### PR TITLE
feat: generate enum marshal and unmarshal separately

### DIFF
--- a/generator/golang/option.go
+++ b/generator/golang/option.go
@@ -24,7 +24,9 @@ import (
 
 // Features controls the behavior of CodeUtils.
 type Features struct {
-	MarshalEnumToText      bool `json_enum_as_text:"Generate MarshalText for enum values"`
+	MarshalEnumToText      bool `json_enum_as_text:"Generate MarshalText and UnmarshalText for enum values"`
+	MarshalEnum            bool `enum_marshal:"Generate MarshalText for enum values"`
+	UnmarshalEnum          bool `enum_unmarshal:"Generate UnmarshalText for enum values"`
 	GenerateSetter         bool `gen_setter:"Generate Set* methods for fields"`
 	GenDatabaseTag         bool `gen_db_tag:"Generate 'db:$field' tag"`
 	GenOmitEmptyTag        bool `omitempty_for_optional:"Generate 'omitempty' tags for optional fields."`
@@ -56,6 +58,8 @@ type Features struct {
 
 var defaultFeatures = Features{
 	MarshalEnumToText:      false,
+	MarshalEnum:            false,
+	UnmarshalEnum:          false,
 	GenerateSetter:         false,
 	GenDatabaseTag:         false,
 	GenOmitEmptyTag:        true,

--- a/generator/golang/templates/enum.go
+++ b/generator/golang/templates/enum.go
@@ -53,11 +53,15 @@ func {{$EnumType}}FromString(s string) ({{$EnumType}}, error) {
 
 func {{$EnumType}}Ptr(v {{$EnumType}} ) *{{$EnumType}}  { return &v }
 
-{{- if Features.MarshalEnumToText}}
+{{- if or Features.MarshalEnumToText Features.MarshalEnum}}
 
 func (p {{$EnumType}}) MarshalText() ([]byte, error) {
 	return []byte(p.String()), nil
 }
+
+{{end}}{{/* if or Features.MarshalEnumToText Features.MarshalEnum */}}
+
+{{- if or Features.MarshalEnumToText Features.UnmarshalEnum}}
 
 func (p *{{$EnumType}}) UnmarshalText(text []byte) error {
 	q, err := {{$EnumType}}FromString(string(text))
@@ -67,7 +71,7 @@ func (p *{{$EnumType}}) UnmarshalText(text []byte) error {
 	*p = q
 	return nil
 }
-{{- end}}{{/* if Features.MarshalEnumToText */}}
+{{end}}{{/* if or Features.MarshalEnumToText Features.UnmarshalEnum */}}
 
 {{- if Features.ScanValueForEnum}}
 {{- UseStdLibrary "sql" "driver"}}


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
generate enum marshal and unmarshal separately

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
之前的 "json_enum_as_text" 选项的描述说的是 enum 只生成 "marshalText"，结果即生成"marshalText"又生成"unmarshalText"

## Related Issue
<!-- use words like 'fix #123', 'closes #123' -->
