### PR TITLE
feat: add regexp support for method-based trimming

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.13
 
 require (
 	github.com/apache/thrift v0.13.0
+	github.com/dlclark/regexp2 v1.10.0 // indirect
 	golang.org/x/text v0.6.0
 	gopkg.in/yaml.v3 v3.0.1
 )

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/apache/thrift v0.13.0 h1:5hryIiq9gtn+MiLVn0wP37kb/uTeRZgN08WoCsAhIhI=
 github.com/apache/thrift v0.13.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
+github.com/dlclark/regexp2 v1.10.0 h1:+/GIL799phkJqYW+3YbOd8LCcbHzT0Pbo8zl70MHsq0=
+github.com/dlclark/regexp2 v1.10.0/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=

--- a/tool/trimmer/trim/mark.go
+++ b/tool/trimmer/trim/mark.go
@@ -44,7 +44,7 @@ func (t *Trimmer) markService(svc *parser.Service, ast *parser.Thrift, filename 
 		if t.trimMethods != nil {
 			funcName := svc.Name + "." + function.Name
 			for i, method := range t.trimMethods {
-				if funcName == method {
+				if ok, _ := method.MatchString(funcName); ok {
 					t.marks[filename][svc] = true
 					t.markFunction(function, ast, filename)
 					t.trimMethodValid[i] = true
@@ -216,7 +216,7 @@ func (t *Trimmer) traceExtendMethod(father, svc *parser.Service, ast *parser.Thr
 	for _, function := range svc.Functions {
 		funcName := father.Name + "." + function.Name
 		for i, method := range t.trimMethods {
-			if funcName == method {
+			if ok, _ := method.MatchString(funcName); ok {
 				t.marks[filename][svc] = true
 				t.markFunction(function, ast, filename)
 				t.trimMethodValid[i] = true

--- a/tool/trimmer/trim/trimmer.go
+++ b/tool/trimmer/trim/trimmer.go
@@ -20,6 +20,8 @@ import (
 	"regexp"
 	"strings"
 
+	"github.com/dlclark/regexp2"
+
 	"github.com/cloudwego/thriftgo/parser"
 	"github.com/cloudwego/thriftgo/semantic"
 )
@@ -32,7 +34,7 @@ type Trimmer struct {
 	marks  map[string]map[interface{}]bool
 	outDir string
 	// use -m
-	trimMethods      []string
+	trimMethods      []*regexp2.Regexp
 	trimMethodValid  []bool
 	preserveRegex    *regexp.Regexp
 	forceTrimming    bool
@@ -75,7 +77,7 @@ func doTrimAST(ast *parser.Thrift, trimMethods []string, forceTrimming bool, pre
 		return err
 	}
 	trimmer.asts[ast.Filename] = ast
-	trimmer.trimMethods = trimMethods
+	trimmer.trimMethods = make([]*regexp2.Regexp, len(trimMethods))
 	trimmer.trimMethodValid = make([]bool, len(trimMethods))
 	trimmer.forceTrimming = forceTrimming
 	for i, method := range trimMethods {
@@ -88,6 +90,8 @@ func doTrimAST(ast *parser.Thrift, trimMethods []string, forceTrimming bool, pre
 				os.Exit(2)
 			}
 		}
+		trimmer.trimMethods[i], err = regexp2.Compile(trimMethods[i], 0)
+		check(err)
 	}
 	trimmer.preservedStructs = preservedStructs
 	trimmer.markAST(ast)


### PR DESCRIPTION
## Description
add regexp support for method-based trimming(-m) of trimmer tool.
now you can use regexp to match methods-to-trim with something like:
- trimmer -m 'Employee.*\..*' test_cases/sample1.thrift
- trimmer -m '^(?!EmployeeService.getEmployee).*$' test_cases/sample1.thrift

## Motivation and Context
some users need to match or unmatch some custom methods-to-trim.
