### PR TITLE
fix: streaming support including dot-separated thrift file

### DIFF
--- a/.github/workflows/push-check.yml
+++ b/.github/workflows/push-check.yml
@@ -52,6 +52,7 @@ jobs:
           go mod init codegen-test
           go mod edit -replace=github.com/apache/thrift=github.com/apache/thrift@v0.13.0
           go mod edit -replace github.com/cloudwego/thriftgo=${LOCAL_REPO}
+          go mod edit -replace github.com/cloudwego/kitex=github.com/cloudwego/kitex@develop
           go mod tidy
           bash -version
           bash ./codegen_install_check.sh

--- a/generator/golang/templates/client.go
+++ b/generator/golang/templates/client.go
@@ -119,18 +119,17 @@ func (p *{{$ClientName}}) {{- template "FunctionSignature" . -}} {
 }
 {{- if or .Streaming.ClientStreaming .Streaming.ServerStreaming}}
 {{- $arg := index .Arguments 0}}
-{{- $ResponseType := .FunctionType.Name}}
 type {{.Service.GoName}}_{{.Name}}Server interface {
 	{{- UseStdLibrary "streaming" -}}
 	streaming.Stream
 	{{if .Streaming.ClientStreaming }}
-	Recv() (*{{$arg.Type.Name}}, error)
+	Recv() ({{$arg.GoTypeName}}, error)
 	{{end}}
 	{{if .Streaming.ServerStreaming}}
-	Send(*{{$ResponseType}}) error
+	Send({{.ResponseGoTypeName}}) error
 	{{end}}
 	{{if and .Streaming.ClientStreaming (not .Streaming.ServerStreaming) }}
-	SendAndClose(*{{$ResponseType}}) error
+	SendAndClose({{.ResponseGoTypeName}}) error
 	{{end}}
 }
 {{- end}}{{/* Streaming */}}

--- a/generator/golang/templates/service.go
+++ b/generator/golang/templates/service.go
@@ -22,7 +22,7 @@ var FunctionSignature = `
 	{{- $arg := index .Arguments 0}}
 	{{- .GoName}}(
 	{{- if and .Streaming.ServerStreaming (not .Streaming.ClientStreaming) -}}
-		req *{{$arg.Type}}, 
+		req {{$arg.GoTypeName}},
 	{{- end -}}
 		stream {{.Service.GoName}}_{{.Name}}Server) (err error)
 {{- else -}}

--- a/generator/golang/templates/slim/slim.go
+++ b/generator/golang/templates/slim/slim.go
@@ -124,18 +124,17 @@ func (p *{{$TypeName}}) Error() string {
 {{- range .Functions}}
 {{- if or .Streaming.ClientStreaming .Streaming.ServerStreaming}}
 {{- $arg := index .Arguments 0}}
-{{- $ResponseType := .FunctionType.Name}}
 type {{.Service.GoName}}_{{.Name}}Server interface {
 	{{- UseStdLibrary "streaming" -}}
 	streaming.Stream
 	{{if .Streaming.ClientStreaming }}
-	Recv() (*{{$arg.Type.Name}}, error)
+	Recv() ({{$arg.GoTypeName}}, error)
 	{{end}}
 	{{if .Streaming.ServerStreaming}}
-	Send(*{{$ResponseType}}) error
+	Send({{.ResponseGoTypeName}}) error
 	{{end}}
 	{{if and .Streaming.ClientStreaming (not .Streaming.ServerStreaming) }}
-	SendAndClose(*{{$ResponseType}}) error
+	SendAndClose({{.ResponseGoTypeName}}) error
 	{{end}}
 }
 {{- end}}{{/* Streaming */}}

--- a/version/version.go
+++ b/version/version.go
@@ -14,4 +14,4 @@
 
 package version
 
-const ThriftgoVersion = "0.3.5"
+const ThriftgoVersion = "0.3.6"


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Fix the failure for Thrift Streaming when a thrift file is including another thrift file with name `a.b.c.thrift`.


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


## Related Issue
<!-- use words like 'fix #123', 'closes #123' -->
