### PR TITLE
fix: fix quote for trimmer

### DIFF
--- a/tool/trimmer/dump/dump.go
+++ b/tool/trimmer/dump/dump.go
@@ -38,7 +38,7 @@ func DumpIDL(ast *parser.Thrift) (string, error) {
 		return "", err
 	}
 	// deal with \\
-	escapedString := strings.Replace(buf.String(), "&#34;", "\\\"", -1)
+	escapedString := strings.Replace(buf.String(), "&#34;", "\"", -1)
 	outString := strings.Replace(escapedString, "#OUTQUOTES", "\"", -1)
 	return html.UnescapeString(outString), nil
 }


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
fix trimmer when parsing escapingString with ""

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


## Related Issue
<!-- use words like 'fix #123', 'closes #123' -->
