### PR TITLE
feat: support referring Interface type and Alias type

### DIFF
--- a/generator/golang/option.go
+++ b/generator/golang/option.go
@@ -24,80 +24,84 @@ import (
 
 // Features controls the behavior of CodeUtils.
 type Features struct {
-	MarshalEnumToText      bool `json_enum_as_text:"Generate MarshalText and UnmarshalText for enum values"`
-	MarshalEnum            bool `enum_marshal:"Generate MarshalText for enum values"`
-	UnmarshalEnum          bool `enum_unmarshal:"Generate UnmarshalText for enum values"`
-	GenerateSetter         bool `gen_setter:"Generate Set* methods for fields"`
-	GenDatabaseTag         bool `gen_db_tag:"Generate 'db:$field' tag"`
-	GenOmitEmptyTag        bool `omitempty_for_optional:"Generate 'omitempty' tags for optional fields."`
-	TypedefAsTypeAlias     bool `use_type_alias:"Generate type alias for typedef instead of type define."`
-	ValidateSet            bool `validate_set:"Generate codes to validate the uniqueness of set elements."`
-	ValueTypeForSIC        bool `value_type_in_container:"Generate value type for struct-like in container instead of pointer type."`
-	ScanValueForEnum       bool `scan_value_for_enum:"Generate Scan and Value methods for enums to implement interfaces in std sql library."`
-	ReorderFields          bool `reorder_fields:"Reorder fields of structs to improve memory usage."`
-	TypedEnumString        bool `typed_enum_string:"Add type prefix to the string representation of enum values."`
-	KeepUnknownFields      bool `keep_unknown_fields:"Generate codes to store unrecognized fields in structs."`
-	GenDeepEqual           bool `gen_deep_equal:"Generate DeepEqual function for struct/union/exception."`
-	CompatibleNames        bool `compatible_names:"Add a '_' suffix if an name has a prefix 'New' or suffix 'Args' or 'Result'."`
-	ReserveComments        bool `reserve_comments:"Reserve comments of definitions in thrift file"`
-	NilSafe                bool `nil_safe:"Generate nil-safe getters."`
-	FrugalTag              bool `frugal_tag:"Generate 'frugal' tags."`
-	EscapeDoubleInTag      bool `unescape_double_quote:"Unescape the double quotes in literals when generating go tags."`
-	GenerateTypeMeta       bool `gen_type_meta:"Generate and register type meta for structures."`
-	GenerateJSONTag        bool `gen_json_tag:"Generate struct with 'json' tag"`
-	AlwaysGenerateJSONTag  bool `always_gen_json_tag:"Always generate 'json' tag even if go.tag is provided (Disabled by default)"`
-	SnakeTyleJSONTag       bool `snake_style_json_tag:"Generate snake style json tag"`
-	LowerCamelCaseJSONTag  bool `lower_camel_style_json_tag:"Generate lower camel case style json tag"`
-	GenerateReflectionInfo bool `generate_reflection_info:"This option is no longer used. Please use with_reflection instead."`
-	WithReflection         bool `with_reflection:"Generate reflection info"`
-	EnumAsINT32            bool `enum_as_int_32:"Generate enum type as int32"`
-	CodeRefSlim            bool `code_ref_slim:"Generate code ref by given idl-ref.yaml with less refs to avoid conflict"`
-	CodeRef                bool `code_ref:"Generate code ref by given idl-ref.yaml"`
-	KeepCodeRefName        bool `keep_code_ref_name:"Generate code ref but still keep file name."`
-	TrimIDL                bool `trim_idl:"Simplify IDL to the most concise form before generating code."`
-	EnableNestedStruct     bool `enable_nested_struct:"Generate nested field when 'thrift.nested=\"true\"' annotation is set to field, valid only in 'slim template'"`
-	JSONStringer           bool `json_stringer:"Generate the JSON marshal method in String() method."`
-	WithFieldMask          bool `with_field_mask:"Support field-mask for generated code."`
-	FieldMaskHalfway       bool `field_mask_halfway:"Support set field-mask on not-root struct."`
-	FieldMaskZeroRequired  bool `field_mask_zero_required:"Write zero value instead of current value for required fields filtered by fieldmask."`
-	ThriftStreaming        bool `thrift_streaming:"Recognize thrift streaming annotation and generate streaming code."`
-	NoDefaultSerdes        bool `no_default_serdes:"Do not generate default thrift serdes code."`
+	MarshalEnumToText           bool `json_enum_as_text:"Generate MarshalText and UnmarshalText for enum values"`
+	MarshalEnum                 bool `enum_marshal:"Generate MarshalText for enum values"`
+	UnmarshalEnum               bool `enum_unmarshal:"Generate UnmarshalText for enum values"`
+	GenerateSetter              bool `gen_setter:"Generate Set* methods for fields"`
+	GenDatabaseTag              bool `gen_db_tag:"Generate 'db:$field' tag"`
+	GenOmitEmptyTag             bool `omitempty_for_optional:"Generate 'omitempty' tags for optional fields."`
+	TypedefAsTypeAlias          bool `use_type_alias:"Generate type alias for typedef instead of type define."`
+	ValidateSet                 bool `validate_set:"Generate codes to validate the uniqueness of set elements."`
+	ValueTypeForSIC             bool `value_type_in_container:"Generate value type for struct-like in container instead of pointer type."`
+	ScanValueForEnum            bool `scan_value_for_enum:"Generate Scan and Value methods for enums to implement interfaces in std sql library."`
+	ReorderFields               bool `reorder_fields:"Reorder fields of structs to improve memory usage."`
+	TypedEnumString             bool `typed_enum_string:"Add type prefix to the string representation of enum values."`
+	KeepUnknownFields           bool `keep_unknown_fields:"Generate codes to store unrecognized fields in structs."`
+	GenDeepEqual                bool `gen_deep_equal:"Generate DeepEqual function for struct/union/exception."`
+	CompatibleNames             bool `compatible_names:"Add a '_' suffix if an name has a prefix 'New' or suffix 'Args' or 'Result'."`
+	ReserveComments             bool `reserve_comments:"Reserve comments of definitions in thrift file"`
+	NilSafe                     bool `nil_safe:"Generate nil-safe getters."`
+	FrugalTag                   bool `frugal_tag:"Generate 'frugal' tags."`
+	EscapeDoubleInTag           bool `unescape_double_quote:"Unescape the double quotes in literals when generating go tags."`
+	GenerateTypeMeta            bool `gen_type_meta:"Generate and register type meta for structures."`
+	GenerateJSONTag             bool `gen_json_tag:"Generate struct with 'json' tag"`
+	AlwaysGenerateJSONTag       bool `always_gen_json_tag:"Always generate 'json' tag even if go.tag is provided (Disabled by default)"`
+	SnakeTyleJSONTag            bool `snake_style_json_tag:"Generate snake style json tag"`
+	LowerCamelCaseJSONTag       bool `lower_camel_style_json_tag:"Generate lower camel case style json tag"`
+	GenerateReflectionInfo      bool `generate_reflection_info:"This option is no longer used. Please use with_reflection instead."`
+	WithReflection              bool `with_reflection:"Generate reflection info"`
+	EnumAsINT32                 bool `enum_as_int_32:"Generate enum type as int32"`
+	CodeRefSlim                 bool `code_ref_slim:"Generate code ref by given idl-ref.yaml with less refs to avoid conflict"`
+	CodeRef                     bool `code_ref:"Generate code ref by given idl-ref.yaml"`
+	KeepCodeRefName             bool `keep_code_ref_name:"Generate code ref but still keep file name."`
+	TrimIDL                     bool `trim_idl:"Simplify IDL to the most concise form before generating code."`
+	EnableNestedStruct          bool `enable_nested_struct:"Generate nested field when 'thrift.nested=\"true\"' annotation is set to field, valid only in 'slim template'"`
+	JSONStringer                bool `json_stringer:"Generate the JSON marshal method in String() method."`
+	WithFieldMask               bool `with_field_mask:"Support field-mask for generated code."`
+	FieldMaskHalfway            bool `field_mask_halfway:"Support set field-mask on not-root struct."`
+	FieldMaskZeroRequired       bool `field_mask_zero_required:"Write zero value instead of current value for required fields filtered by fieldmask."`
+	ThriftStreaming             bool `thrift_streaming:"Recognize thrift streaming annotation and generate streaming code."`
+	NoDefaultSerdes             bool `no_default_serdes:"Do not generate default thrift serdes code."`
+	NoAliasTypeReflectionMethod bool `no_alias_type_reflection_method:"Refer alias type without generating type related methods in <idl>_reflection.go when 'thrift.is_alias=\"true\"' annotation is set to types in referred thrift, valid only in 'slim template'"`
+	EnableRefInterface          bool `enable_ref_interface:"Generate Interface field without pointer type when 'thrift.is_interface=\"true\"' annotation is set to types in referred thrift, valid only in 'slim template'"`
 }
 
 var defaultFeatures = Features{
-	MarshalEnumToText:      false,
-	MarshalEnum:            false,
-	UnmarshalEnum:          false,
-	GenerateSetter:         false,
-	GenDatabaseTag:         false,
-	GenOmitEmptyTag:        true,
-	TypedefAsTypeAlias:     true,
-	ValidateSet:            true,
-	ValueTypeForSIC:        false,
-	ScanValueForEnum:       true,
-	ReorderFields:          false,
-	TypedEnumString:        false,
-	KeepUnknownFields:      false,
-	GenDeepEqual:           false,
-	CompatibleNames:        false,
-	ReserveComments:        false,
-	NilSafe:                false,
-	FrugalTag:              false,
-	EscapeDoubleInTag:      true,
-	GenerateTypeMeta:       false,
-	GenerateJSONTag:        true,
-	AlwaysGenerateJSONTag:  false,
-	SnakeTyleJSONTag:       false,
-	LowerCamelCaseJSONTag:  false,
-	GenerateReflectionInfo: false,
-	ThriftStreaming:        false,
-	EnumAsINT32:            false,
-	TrimIDL:                false,
-	JSONStringer:           false,
-	WithFieldMask:          false,
-	FieldMaskHalfway:       false,
-	FieldMaskZeroRequired:  false,
-	EnableNestedStruct:     false,
+	MarshalEnumToText:           false,
+	MarshalEnum:                 false,
+	UnmarshalEnum:               false,
+	GenerateSetter:              false,
+	GenDatabaseTag:              false,
+	GenOmitEmptyTag:             true,
+	TypedefAsTypeAlias:          true,
+	ValidateSet:                 true,
+	ValueTypeForSIC:             false,
+	ScanValueForEnum:            true,
+	ReorderFields:               false,
+	TypedEnumString:             false,
+	KeepUnknownFields:           false,
+	GenDeepEqual:                false,
+	CompatibleNames:             false,
+	ReserveComments:             false,
+	NilSafe:                     false,
+	FrugalTag:                   false,
+	EscapeDoubleInTag:           true,
+	GenerateTypeMeta:            false,
+	GenerateJSONTag:             true,
+	AlwaysGenerateJSONTag:       false,
+	SnakeTyleJSONTag:            false,
+	LowerCamelCaseJSONTag:       false,
+	GenerateReflectionInfo:      false,
+	ThriftStreaming:             false,
+	EnumAsINT32:                 false,
+	TrimIDL:                     false,
+	JSONStringer:                false,
+	WithFieldMask:               false,
+	FieldMaskHalfway:            false,
+	FieldMaskZeroRequired:       false,
+	EnableNestedStruct:          false,
+	NoAliasTypeReflectionMethod: false,
+	EnableRefInterface:          false,
 }
 
 type param struct {

--- a/generator/golang/option.go
+++ b/generator/golang/option.go
@@ -62,8 +62,8 @@ type Features struct {
 	FieldMaskZeroRequired       bool `field_mask_zero_required:"Write zero value instead of current value for required fields filtered by fieldmask."`
 	ThriftStreaming             bool `thrift_streaming:"Recognize thrift streaming annotation and generate streaming code."`
 	NoDefaultSerdes             bool `no_default_serdes:"Do not generate default thrift serdes code."`
-	NoAliasTypeReflectionMethod bool `no_alias_type_reflection_method:"Refer alias type without generating type related methods in <idl>_reflection.go when 'thrift.is_alias=\"true\"' annotation is set to types in referred thrift, valid only in 'slim template'"`
-	EnableRefInterface          bool `enable_ref_interface:"Generate Interface field without pointer type when 'thrift.is_interface=\"true\"' annotation is set to types in referred thrift, valid only in 'slim template'"`
+	NoAliasTypeReflectionMethod bool `no_alias_type_reflection_method:"Do not generate type related methods in <idl>_reflection.go when 'thrift.is_alias=\"true\"' annotation is set to types."`
+	EnableRefInterface          bool `enable_ref_interface:"Generate Interface field without pointer type when 'thrift.is_interface=\"true\"' annotation is set to types in referred thrift."`
 }
 
 var defaultFeatures = Features{

--- a/generator/golang/scope.go
+++ b/generator/golang/scope.go
@@ -565,9 +565,10 @@ func (f *Field) IsNested() bool {
 // StructLike is a wrapper for the parser.StructLike.
 type StructLike struct {
 	*parser.StructLike
-	scope  namespace.Namespace
-	name   Name
-	fields []*Field
+	scope   namespace.Namespace
+	name    Name
+	fields  []*Field
+	isAlias bool
 }
 
 // GoName returns the name in go code of the struct-like.
@@ -594,6 +595,11 @@ func (s *StructLike) Fields() []*Field {
 // Namespace returns the namescope of the struct-like.
 func (s *StructLike) Namespace() namespace.Namespace {
 	return s.scope
+}
+
+// IsAlias returns whether this type is alias of existing type
+func (s *StructLike) IsAlias() bool {
+	return s.isAlias
 }
 
 // Service is a wrapper for the parser.Service.

--- a/generator/golang/scope_internal.go
+++ b/generator/golang/scope_internal.go
@@ -16,6 +16,7 @@ package golang
 
 import (
 	"fmt"
+	"log"
 	"runtime/debug"
 	"strconv"
 	"strings"
@@ -30,7 +31,9 @@ const (
 	// A prefix to denote synthesized identifiers.
 	prefix = "$"
 	// nestedAnnotation is to denote the field is nested type.
-	nestedAnnotation = "thrift.nested"
+	nestedAnnotation    = "thrift.nested"
+	interfaceAnnotation = "thrift.is_interface"
+	aliasAnnotation     = "thrift.is_alias"
 )
 
 func _p(id string) string {
@@ -386,6 +389,10 @@ func (s *Scope) buildStructLike(cu *CodeUtils, v *parser.StructLike, usedName ..
 		})
 	}
 
+	if cu.Features().NoAliasTypeReflectionMethod && isAliasType(v) {
+		st.isAlias = true
+	}
+
 	if len(usedName) > 0 {
 		s.synthesized = append(s.synthesized, st)
 	} else {
@@ -497,12 +504,29 @@ func (s *Scope) resolveTypesAndValues(cu *CodeUtils) {
 }
 
 func isNestedField(f *parser.Field) bool {
-	annos := f.Annotations.Get(nestedAnnotation)
-	if len(annos) == 0 {
+	return annotationContainsTrue(f.Annotations, nestedAnnotation)
+}
+
+func isAliasType(s *parser.StructLike) bool {
+	return annotationContainsTrue(s.Annotations, aliasAnnotation)
+}
+
+func isRefInterfaceField(g *Scope, f *parser.Field) bool {
+	return isRefInterfaceType(g, f.Type)
+}
+
+func annotationContainsTrue(annos parser.Annotations, anno string) bool {
+	vals := annos.Get(anno)
+	if len(vals) == 0 {
 		return false
 	}
-	if strings.EqualFold(annos[0], "true") {
+	if len(vals) > 1 {
+		log.Printf("[WARN] %s annotation has been set multiple values", anno)
+		return false
+	}
+	if strings.EqualFold(vals[0], "true") {
 		return true
 	}
+
 	return false
 }

--- a/generator/golang/templates/reflection/reflection_tpl.go
+++ b/generator/golang/templates/reflection/reflection_tpl.go
@@ -74,6 +74,7 @@ func GetFileDescriptorFor{{ToCamel $IDLName}}() *thrift_reflection.FileDescripto
 }
 
 {{- range .Structs}}
+{{- if not .IsAlias}}
 func (p *{{.GoName}}) GetDescriptor() *thrift_reflection.StructDescriptor{
 	return file_{{$IDLName}}_thrift.GetStructDescriptor("{{.Name}}")
 }
@@ -85,7 +86,9 @@ func (p *{{.GoName}}) GetTypeDescriptor() *thrift_reflection.TypeDescriptor{
 	return ret
 }
 {{- end}}
+{{- end}}
 {{- range .Enums}}
+{{- if not .IsAlias}}
 func (p {{.GoName}}) GetDescriptor() *thrift_reflection.EnumDescriptor{
 	return file_{{$IDLName}}_thrift.GetEnumDescriptor("{{.Name}}")
 }
@@ -97,7 +100,9 @@ func (p *{{.GoName}}) GetTypeDescriptor() *thrift_reflection.TypeDescriptor{
 	return ret
 }
 {{- end}}
+{{- end}}
 {{- range .Unions}}
+{{- if not .IsAlias}}
 func (p *{{.GoName}}) GetDescriptor() *thrift_reflection.StructDescriptor{
 	return file_{{$IDLName}}_thrift.GetUnionDescriptor("{{.Name}}")
 }
@@ -109,7 +114,9 @@ func (p *{{.GoName}}) GetTypeDescriptor() *thrift_reflection.TypeDescriptor{
 	return ret
 }
 {{- end}}
+{{- end}}
 {{- range .Exceptions}}
+{{- if not .IsAlias}}
 func (p *{{.GoName}}) GetDescriptor() *thrift_reflection.StructDescriptor{
 	return file_{{$IDLName}}_thrift.GetExceptionDescriptor("{{.Name}}")
 }
@@ -120,6 +127,7 @@ func (p *{{.GoName}}) GetTypeDescriptor() *thrift_reflection.TypeDescriptor{
 	ret.Name = "{{.Name}}"
 	return ret
 }
+{{- end}}
 {{- end}}
 
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
1. Generating Alias type reflection content without related type methods => add ```thrift.is_alias="true"``` and enable ```no_alias_type_reflection_method```
e.g.
```
namespace go extensions

struct BigDecimal {} (JavaClassName="java.math.BigDecimal", thrift.is_alias="true")

struct BigInteger {} (JavaClassName="java.math.BigInteger", thrift.is_alias="true")
```
Not add ```thrift.is_alias``` tag, thriftgo would generate type methods:
<img width="625" alt="image" src="https://github.com/cloudwego/thriftgo/assets/33331974/089f5193-0051-40e7-b11e-2665b89d44ac">
After adding this tag, thriftgo would not generate.

2. Referring Interface type => add ```thrift.is_interface="true"``` to referred type and enable ```enable_ref_interface```
e.g.
```
namespace go java

struct Object {} (JavaClassName="java.lang.Object", thrift.is_interface="true")

struct Date {} (JavaClassName="java.util.Date")

struct Exception {} (JavaClassName="java.lang.Exception")
```
Not adding ```thrift.is_interface``` tag, thriftgo would add pointer to referred Interface type:
<img width="991" alt="image" src="https://github.com/cloudwego/thriftgo/assets/33331974/03340646-be29-4637-91fc-8407deaf5d42">
After adding this tag:
<img width="953" alt="image" src="https://github.com/cloudwego/thriftgo/assets/33331974/c686be1e-360c-4495-b1b5-b236c3bc17dd">

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


## Related Issue
<!-- use words like 'fix #123', 'closes #123' -->
