### PR TITLE
Dump function annotations in thrift files

### DIFF
--- a/tool/trimmer/dump/dump_test.go
+++ b/tool/trimmer/dump/dump_test.go
@@ -29,8 +29,13 @@ func TestDumpSingle(t *testing.T) {
 	filename := filepath.Join("..", "test_cases", "sample1.thrift")
 	ast, err := parser.ParseFile(filename, []string{"test_cases"}, true)
 	test.Assert(t, err == nil, err)
-	_, err = DumpIDL(ast)
+	out, err := DumpIDL(ast)
 	test.Assert(t, err == nil, err)
+
+	// tests for function annotations
+	test.Assert(t, strings.Contains(out, "api.get"), "output should contains function annotations")
+	test.Assert(t, strings.Contains(out, "api.post"), "output should contains function annotations")
+	test.Assert(t, strings.Contains(out, "api.put"), "output should contains function annotations")
 }
 
 func TestDumpMany(t *testing.T) {

--- a/tool/trimmer/dump/field_template.go
+++ b/tool/trimmer/dump/field_template.go
@@ -162,6 +162,7 @@ const FunctionTemplate = `
 {{- if $index}},{{end -}}{{- template "SingleLineField" .}}
 {{- end}})
 {{- end}}
+{{- template "Annotations" .Annotations -}}
 {{- end -}}
 `
 

--- a/tool/trimmer/test_cases/sample1.thrift
+++ b/tool/trimmer/test_cases/sample1.thrift
@@ -117,14 +117,13 @@ service EmployeeService extends sample1b.GetPerson {
 service ProjectService {
     Project getProject(1: string id)
     oneway void addProject(1: Project project)
-    void updateProject(1: string id,
-    2: Project project)
+    void updateProject(1: string id, 2: Project project)
 }
 
 service CompanyService {
-    Company getCompany(1: string id)
-    void addCompany(1: Company company) throws(1: samlpe1bAnotherException exc)
-    void updateCompany(1: string id, 2: Company company)
+    Company getCompany(1: string id) (api.get = "/company")
+    void addCompany(1: Company company) throws(1: samlpe1bAnotherException exc) (api.put = "/company")
+    void updateCompany(1: string id, 2: Company company) (api.post = "/company")
     list<sample1b.Department> getDepartments(1: string company_id)
     void anotherUselessMethod(1: MaybeUseless useless)
 }


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
When using dump tool to translate an ast into thrift files, annotations of functions will disappear in dumped file.
And this PR fix this bug.

## Related Issue
closes #170