### PR TITLE
optimize: generate the go type for const

### DIFF
--- a/generator/golang/templates/constant.go
+++ b/generator/golang/templates/constant.go
@@ -23,7 +23,7 @@ const (
 	{{- range $Consts}}
 	{{InsertionPoint "constant" .Name}}
 	{{- if and Features.ReserveComments .ReservedComments}}{{.ReservedComments}}{{end}}
-	{{.GoName}} = {{.Initialization}}
+	{{.GoName}} {{.GoTypeName}} = {{.Initialization}}
 	{{- end}}{{/* range $Consts */}}
 	{{InsertionPoint "constants"}}
 )


### PR DESCRIPTION
Change-Id: I53ea6980c732f71c6fd27b527e24155ce54f8666

## Description
add const type 


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
`const` definition is generated without specified type. 
It's confusing for client users to find optional values of that type. In my opinion, when typedef types and corresponding values are defined, it is to inform users of the available values of that type.
<!--- If it fixes an open issue, please link to the issue here. -->
https://github.com/cloudwego/thriftgo/issues/174

## Related Issue
<!-- use words like 'fix #123', 'closes #123' -->
