### PR TITLE
optimize: add a new option to not generate processor and thrift client

### DIFF
--- a/generator/golang/option.go
+++ b/generator/golang/option.go
@@ -66,8 +66,9 @@ type Features struct {
 	EnableRefInterface          bool `enable_ref_interface:"Generate Interface field without pointer type when 'thrift.is_interface=\"true\"' annotation is set to types in referred thrift."`
 	UseOption                   bool `use_option:"Parse specific Thrift annotations into struct-style option fields. If key not match, thriftgo will just ignore it."`
 	// ForceUseOption         bool `use_option:"Forcefully parse all Thrift annotations into struct-style option fields. If parsing is not possible, an error will be thrown."`
-	NoFmt     bool `no_fmt:"To achieve faster generation speed, skipping the formatting of Golang code can improve performance by approximately 50%."`
-	SkipEmpty bool `skip_empty:"If there's not content in file, just skip it. Later this feature will be a default feature."`
+	NoFmt       bool `no_fmt:"To achieve faster generation speed, skipping the formatting of Golang code can improve performance by approximately 50%."`
+	SkipEmpty   bool `skip_empty:"If there's not content in file, just skip it. Later this feature will be a default feature."`
+	NoProcessor bool `no_processor:" Do not generate default thrift processor and client. Later this feature will be a default feature."`
 }
 
 var defaultFeatures = Features{

--- a/generator/golang/templates/client.go
+++ b/generator/golang/templates/client.go
@@ -17,6 +17,7 @@ package templates
 // Client .
 var Client = `
 {{define "ThriftClient"}}
+{{- if not Features.NoProcessor}}
 {{- UseStdLibrary "thrift"}}
 {{- $BasePrefix := ServicePrefix .Base}}
 {{- $BaseService := ServiceName .Base}}
@@ -134,5 +135,6 @@ type {{.Service.GoName}}_{{.Name}}Server interface {
 }
 {{- end}}{{/* Streaming */}}
 {{- end}}{{/* range .Functions */}}
+{{- end}}{{/* if not Features.NoProcessor */}}
 {{- end}}{{/* define "ThriftClient" */}}
 `

--- a/generator/golang/templates/processor.go
+++ b/generator/golang/templates/processor.go
@@ -17,6 +17,7 @@ package templates
 // Processor .
 var Processor = `
 {{define "ThriftProcessor"}}
+{{- if not Features.NoProcessor}}
 {{- UseStdLibrary "thrift"}}
 {{- $BasePrefix := ServicePrefix .Base}}
 {{- $BaseService := ServiceName .Base}}
@@ -171,6 +172,7 @@ func (p *{{$ProcessName}}) Process(ctx context.Context, seqId int32, iprot, opro
 	{{- end -}}{{- /* end if not Has Streaming */ -}}
 }
 {{- end}}{{/* range .Functions */}}
+{{- end}}{{/* if not Features.NoProcessor */}}
 
 {{- range .Functions}}
 {{$ArgsType := .ArgType}}


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
add a new option 'no_processor' to not generate processor and thrift client

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


## Related Issue
<!-- use words like 'fix #123', 'closes #123' -->
