### PR TITLE
optimize: trimmer match method go name

### DIFF
--- a/tool/trimmer/trim/config.go
+++ b/tool/trimmer/trim/config.go
@@ -28,6 +28,7 @@ type YamlArguments struct {
 	Methods          []string `yaml:"methods,omitempty"`
 	Preserve         *bool    `yaml:"preserve,omitempty"`
 	PreservedStructs []string `yaml:"preserved_structs,omitempty"`
+	MatchGoName      *bool    `yaml:"match_go_name,omitempty"`
 }
 
 func ParseYamlConfig(path string) *YamlArguments {
@@ -45,6 +46,10 @@ func ParseYamlConfig(path string) *YamlArguments {
 	if cfg.Preserve == nil {
 		t := true
 		cfg.Preserve = &t
+	}
+	if cfg.MatchGoName == nil {
+		t := false
+		cfg.MatchGoName = &t
 	}
 	return &cfg
 }

--- a/tool/trimmer/trim/mark.go
+++ b/tool/trimmer/trim/mark.go
@@ -31,6 +31,18 @@ func (t *Trimmer) markAST(ast *parser.Thrift) {
 	t.markKeptPart(ast, ast.Filename)
 }
 
+func toGoName(input string) string {
+	words := strings.Split(input, "_")
+	var result strings.Builder
+	for _, word := range words {
+		if word != "" {
+			upperWord := strings.ToUpper(string(word[0])) + word[1:]
+			result.WriteString(upperWord)
+		}
+	}
+	return result.String()
+}
+
 func (t *Trimmer) markService(svc *parser.Service, ast *parser.Thrift, filename string) {
 	if t.marks[filename][svc] {
 		return
@@ -44,6 +56,9 @@ func (t *Trimmer) markService(svc *parser.Service, ast *parser.Thrift, filename 
 		if len(t.trimMethods) != 0 {
 			funcName := svc.Name + "." + function.Name
 			for i, method := range t.trimMethods {
+				if t.matchGoName {
+					funcName = svc.Name + "." + toGoName(function.Name)
+				}
 				if ok, _ := method.MatchString(funcName); ok {
 					if funcName == method.String() || !strings.HasPrefix(funcName, method.String()) {
 						t.marks[filename][svc] = true

--- a/tool/trimmer/trim/trimmer.go
+++ b/tool/trimmer/trim/trimmer.go
@@ -35,6 +35,7 @@ type Trimmer struct {
 	outDir string
 	// use -m
 	trimMethods      []*regexp2.Regexp
+	matchGoName      bool
 	trimMethodValid  []bool
 	preserveRegex    *regexp.Regexp
 	forceTrimming    bool
@@ -47,6 +48,7 @@ type TrimASTArg struct {
 	Ast         *parser.Thrift
 	TrimMethods []string
 	Preserve    *bool
+	MatchGoName *bool
 }
 
 // TrimAST parse the cfg and trim the single AST
@@ -62,6 +64,9 @@ func TrimAST(arg *TrimASTArg) (structureTrimmed int, fieldTrimmed int, err error
 				preserve := false
 				arg.Preserve = &preserve
 			}
+			if arg.MatchGoName == nil && cfg.MatchGoName != nil {
+				arg.MatchGoName = cfg.MatchGoName
+			}
 			preservedStructs = cfg.PreservedStructs
 		}
 	}
@@ -69,11 +74,15 @@ func TrimAST(arg *TrimASTArg) (structureTrimmed int, fieldTrimmed int, err error
 	if arg.Preserve != nil {
 		forceTrim = !*arg.Preserve
 	}
-	return doTrimAST(arg.Ast, arg.TrimMethods, forceTrim, preservedStructs)
+	matchGoName := false
+	if arg.MatchGoName != nil {
+		matchGoName = *arg.MatchGoName
+	}
+	return doTrimAST(arg.Ast, arg.TrimMethods, forceTrim, matchGoName, preservedStructs)
 }
 
 // doTrimAST trim the single AST, pass method names if -m specified
-func doTrimAST(ast *parser.Thrift, trimMethods []string, forceTrimming bool, preservedStructs []string) (
+func doTrimAST(ast *parser.Thrift, trimMethods []string, forceTrimming bool, matchGoName bool, preservedStructs []string) (
 	structureTrimmed int, fieldTrimmed int, err error) {
 	trimmer, err := newTrimmer(nil, "")
 	if err != nil {
@@ -83,15 +92,16 @@ func doTrimAST(ast *parser.Thrift, trimMethods []string, forceTrimming bool, pre
 	trimmer.trimMethods = make([]*regexp2.Regexp, len(trimMethods))
 	trimmer.trimMethodValid = make([]bool, len(trimMethods))
 	trimmer.forceTrimming = forceTrimming
+	trimmer.matchGoName = matchGoName
 	for i, method := range trimMethods {
 		parts := strings.Split(method, ".")
 		if len(parts) < 2 {
 			if len(ast.Services) == 1 {
 				trimMethods[i] = ast.Services[0].Name + "." + method
 			} else {
-                                trimMethods[i] = ast.Services[len(ast.Services)-1].Name + "." + method
-                                // println("please specify service name!\n  -m usage: -m [service_name.method_name]")
-                                // os.Exit(2)
+				trimMethods[i] = ast.Services[len(ast.Services)-1].Name + "." + method
+				// println("please specify service name!\n  -m usage: -m [service_name.method_name]")
+				// os.Exit(2)
 
 			}
 		}


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
trimmer 的配置文件里，Method 默认是 IDL 的名称，会通过传入的名称与 IDL 里的进行对比
但有的场景，Method 写的是 Golang 风格的名称，这里提供一个额外的参数 MatchGoName，用来将 IDL 里的 Method 转化为 Golang 风格，以此完成匹配

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


## Related Issue
<!-- use words like 'fix #123', 'closes #123' -->
