### PR TITLE
optimize: optimize for thriftgo sdk

### DIFF
--- a/args/args.go
+++ b/args/args.go
@@ -255,7 +255,6 @@ Available generators (and options): go
 	//	println(align(b.Options()))
 	//}
 	println()
-	os.Exit(2)
 }
 
 // align the help strings for plugin options.

--- a/main.go
+++ b/main.go
@@ -20,6 +20,8 @@ import (
 	"runtime/debug"
 	"runtime/pprof"
 
+	"github.com/cloudwego/thriftgo/config"
+
 	"time"
 
 	"github.com/cloudwego/thriftgo/args"
@@ -39,6 +41,10 @@ var (
 var debugMode bool
 
 func init() {
+	err := config.LoadConfig()
+	if err != nil {
+		panic(err)
+	}
 	_ = g.RegisterBackend(new(golang.GoBackend))
 	// export THRIFTGO_DEBUG=1
 	debugMode = os.Getenv("THRIFTGO_DEBUG") == "1"

--- a/semantic/checker.go
+++ b/semantic/checker.go
@@ -16,6 +16,7 @@ package semantic
 
 import (
 	"fmt"
+	"math"
 
 	"github.com/cloudwego/thriftgo/parser"
 )
@@ -111,6 +112,11 @@ func (c *checker) CheckEnums(t *parser.Thrift) (warns []string, err error) {
 			}
 			v2n[v.Value] = v.Name
 			if err != nil {
+				return
+			}
+			// check if enum value can be safely converted to int 32
+			if v.Value < math.MinInt32 || v.Value > math.MaxInt32 {
+				err = fmt.Errorf("the value of enum %s is %d, which exceeds the range of int32", v.Name, v.Value)
 				return
 			}
 		}

--- a/utils/dir_utils/dir_utils.go
+++ b/utils/dir_utils/dir_utils.go
@@ -17,6 +17,7 @@ package dir_utils
 import (
 	"os"
 	"path/filepath"
+	"strings"
 )
 
 var globalwd string
@@ -39,4 +40,20 @@ func Getwd() (string, error) {
 	}
 	wantedwd := globalwd
 	return filepath.Rel(currentwd, wantedwd)
+}
+
+func ToAbsolute(k string) (string, error) {
+	if !strings.HasSuffix(k, "/") {
+		wd, err := Getwd()
+		if err != nil {
+			return "", err
+		}
+		k = filepath.Join(wd, k)
+		absK, err := filepath.Abs(k)
+		if err != nil {
+			return "", err
+		}
+		k = absK
+	}
+	return k, nil
 }


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
optimize for thriftgo sdk, since there're some cases the previous pr can't handle well.

1. support 「help」and 「version」for sdk call and return instead of os.Exit
2. optimize public struct ref logic for idl path matcher.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


## Related Issue
<!-- use words like 'fix #123', 'closes #123' -->
