### PR TITLE
fix: init default values when using liner allocator

### DIFF
--- a/generator/golang/templates/slim/slim.go
+++ b/generator/golang/templates/slim/slim.go
@@ -80,13 +80,13 @@ func New{{$TypeName}}() *{{$TypeName}} {
 	}
 }
 
-{{if Features.FrugalTag}}
 func (p *{{$TypeName}}) InitDefault() {
-	*p = {{$TypeName}}{
-		{{template "StructLikeDefault" .}}
-	}
+{{- range .Fields}}
+	{{- if .IsSetDefault}}
+	p.{{.GoName}} = {{.DefaultValue}}
+	{{- end}}
+{{- end}}
 }
-{{end}}{{/* if Features.FrugalTag */}}
 
 {{template "FieldGetOrSet" .}}
 

--- a/generator/golang/templates/struct.go
+++ b/generator/golang/templates/struct.go
@@ -51,13 +51,13 @@ func New{{$TypeName}}() *{{$TypeName}} {
 	}
 }
 
-{{if Features.FrugalTag}}
 func (p *{{$TypeName}}) InitDefault() {
-	*p = {{$TypeName}}{
-		{{template "StructLikeDefault" .}}
-	}
+{{- range .Fields}}
+	{{- if .IsSetDefault}}
+	p.{{.GoName}} = {{.DefaultValue}}
+	{{- end}}
+{{- end}}
 }
-{{end}}{{/* if Features.FrugalTag */}}
 
 {{template "FieldGetOrSet" .}}
 
@@ -650,6 +650,7 @@ var FieldReadMap = `
 		{{- $ctx := (.ValCtx.WithTarget $val).WithFieldMask $curFieldMask}}
 		{{- if $isStructVal}}
 		{{$val}} := &values[i]
+		{{$val}}.InitDefault()
 		{{- else}}
 		{{- $ctx = $ctx.WithDecl}}
 		{{- end}}
@@ -698,6 +699,7 @@ var FieldReadSet = `
 		{{- $ctx := (.ValCtx.WithTarget $val).WithFieldMask $curFieldMask}}
 		{{- if $isStructVal}}
 		{{$val}} := &values[i]
+		{{$val}}.InitDefault()
 		{{- else}}
 		{{- $ctx = $ctx.WithDecl}}
 		{{- end}}
@@ -746,6 +748,7 @@ var FieldReadList = `
 		{{- $ctx := (.ValCtx.WithTarget $val).WithFieldMask $curFieldMask}}
 		{{- if $isStructVal}}
 		{{$val}} := &values[i]
+		{{$val}}.InitDefault()
 		{{- else}}
 		{{- $ctx = $ctx.WithDecl}}
 		{{- end}}


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

If IDL defined default value, it should call InitDefault to force set default values.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


## Related Issue
<!-- use words like 'fix #123', 'closes #123' -->
