### PR TITLE
fix: fix the loading of config

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -27,6 +27,13 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
+func init() {
+	err := LoadConfig()
+	if err != nil {
+		panic(err)
+	}
+}
+
 type RawConfig struct {
 	Ref   map[string]interface{} `yaml:"ref"`
 	Debug bool                   `yaml:"debug"`
@@ -101,6 +108,8 @@ func GetRef(name string) *RefConfig {
 	return refConfig
 }
 
+// LoadConfig by default, config will load only once when the program is invoked, also the same for each plugin
+// but for sdk mode, config should be reloaded each time when the sdk is called. so we provide this api and manually call this in sdk mode.
 func LoadConfig() error {
 	config, err := initConfig()
 	if err != nil {

--- a/main.go
+++ b/main.go
@@ -20,8 +20,6 @@ import (
 	"runtime/debug"
 	"runtime/pprof"
 
-	"github.com/cloudwego/thriftgo/config"
-
 	"time"
 
 	"github.com/cloudwego/thriftgo/args"
@@ -41,10 +39,6 @@ var (
 var debugMode bool
 
 func init() {
-	err := config.LoadConfig()
-	if err != nil {
-		panic(err)
-	}
 	_ = g.RegisterBackend(new(golang.GoBackend))
 	// export THRIFTGO_DEBUG=1
 	debugMode = os.Getenv("THRIFTGO_DEBUG") == "1"


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
fix the loading logic of config.
In previous pr, I remove LoadConfig from init and manully call it in main.go and in sdk api. But for plugin mode, when each plugin program such as validator is invoked, no config is load from init function and it cause errors. So this pr fix this.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


## Related Issue
<!-- use words like 'fix #123', 'closes #123' -->
