### PR TITLE
fix: union missing extra

### DIFF
--- a/thrift_reflection/descriptor_register.go
+++ b/thrift_reflection/descriptor_register.go
@@ -129,7 +129,7 @@ func registerGlobalUUID(fd *FileDescriptor, uuid string) {
 	structs = append(structs, fd.Structs...)
 	structs = append(structs, fd.Unions...)
 	structs = append(structs, fd.Exceptions...)
-	for _, strct := range fd.Structs {
+	for _, strct := range structs {
 		addExtraToDescriptor(uuid, strct)
 		for _, f := range strct.Fields {
 			addExtraToDescriptor(uuid, f)


### PR DESCRIPTION
## Description
Fixed the issue where Union, Exception, and their Field did not have Extra information.

## Motivation and Context
In the `thrift_reflection/descriptor_register.go`, when registerGlobalUUID for all structures (Struct, Union, and Exception), only Struct was traversed. As a result, Union, Exception, and their Field did not have Extra added, which caused methods like `.IsStruct()` for struct fields under Union to return unexpected results.