### PR TITLE
refactor(fastgo): new append method

### DIFF
--- a/generator/fastgo/gen_blength.go
+++ b/generator/fastgo/gen_blength.go
@@ -79,7 +79,8 @@ func genBLengthField(w *codewriter, rwctx *golang.ReadWriteContext, f *golang.Fi
 	}
 
 	// field header
-	w.f("off += 3") // type + fid
+	// 3 will be added in genBLengthAny
+	// w.f("off += 3")
 
 	// field value
 	genBLengthAny(w, rwctx, varname, 0)
@@ -89,7 +90,7 @@ func genBLengthField(w *codewriter, rwctx *golang.ReadWriteContext, f *golang.Fi
 func genBLengthAny(w *codewriter, rwctx *golang.ReadWriteContext, varname string, depth int) {
 	t := rwctx.Type
 	if sz := category2WireSize[t.Category]; sz > 0 {
-		w.f("off += %d", sz)
+		w.f("off += 3 + %d", sz)
 		return
 	}
 	pointer := rwctx.IsPointer
@@ -107,22 +108,22 @@ func genBLengthAny(w *codewriter, rwctx *golang.ReadWriteContext, varname string
 
 func genBLengthBinary(w *codewriter, pointer bool, varname string) {
 	varname = varnameVal(pointer, varname)
-	w.f("off += 4 + len(%s)", varname)
+	w.f("off += 3 + 4 + len(%s)", varname)
 }
 
 func genBLengthString(w *codewriter, pointer bool, varname string) {
 	varname = varnameVal(pointer, varname)
-	w.f("off += 4 + len(%s)", varname)
+	w.f("off += 3 + 4 + len(%s)", varname)
 }
 
 func genBLengthStruct(w *codewriter, _ *golang.ReadWriteContext, varname string) {
-	w.f("off += %s.BLength()", varname)
+	w.f("off += 3 + %s.BLength()", varname)
 }
 
 func genBLengthList(w *codewriter, rwctx *golang.ReadWriteContext, varname string, depth int) {
 	t := rwctx.Type
 	// list header
-	w.f("off += 5")
+	w.f("off += 3 + 5")
 
 	// if element is basic type like int32, we can speed up the calc by sizeof(int32) * len(l)
 	if sz := category2WireSize[t.ValueType.Category]; sz > 0 { // fast path for less code
@@ -146,7 +147,7 @@ func genBLengthMap(w *codewriter, rwctx *golang.ReadWriteContext, varname string
 	vt := t.ValueType
 
 	// map header
-	w.f("off += 6")
+	w.f("off += 3 + 6")
 
 	// iteration tmp var
 	tmpk := "k"

--- a/generator/fastgo/gen_fastread.go
+++ b/generator/fastgo/gen_fastread.go
@@ -106,15 +106,18 @@ func (g *FastGoBackend) genFastRead(w *codewriter, scope *golang.Scope, s *golan
 
 	if len(ff) > 0 { // fix `label ReadFieldError defined and not used`
 		w.f("ReadFieldError:")
-		w.f(`return off, thrift.PrependError(fmt.Sprintf("%%T read field %%d '%%s' error: ", p, fid, fieldIDToName_%s[fid]), err)`, s.GoName())
+		w.f(`return off, thrift.PrependError(
+			fmt.Sprintf("%%T read field %%d '%%s' error: ", p, fid, fieldIDToName_%s[fid]), err)`, s.GoName())
 	}
 
 	w.f("SkipFieldError:")
-	w.f(`return off, thrift.PrependError(fmt.Sprintf("%%T skip field %%d type %%d error: ", p, fid, ftyp), err)`)
+	w.f(`return off, thrift.PrependError(
+		fmt.Sprintf("%%T skip field %%d type %%d error: ", p, fid, ftyp), err)`)
 
 	if isset.Len() > 0 {
 		w.f("RequiredFieldNotSetError:")
-		w.f(`return off, thrift.NewProtocolException(thrift.INVALID_DATA, fmt.Sprintf("required field %%s is not set", fieldIDToName_%s[fid]))`, s.GoName())
+		w.f(`return off, thrift.NewProtocolException(thrift.INVALID_DATA,
+		fmt.Sprintf("required field %%s is not set", fieldIDToName_%s[fid]))`, s.GoName())
 	}
 
 	// end of func definition

--- a/test/fastgo/Makefile
+++ b/test/fastgo/Makefile
@@ -1,4 +1,4 @@
-# Copyright 2022 CloudWeGo Authors
+# Copyright 2024 CloudWeGo Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -11,33 +11,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+#
+.PHONY: all
 
-OUT=$(PWD)/testdata
-IDL=$(OUT)/x.thrift
-COV_PROF=$(OUT)/cov.out
-
-export IDL
-
-.PHONY: all clean
-all: lint test bench
-
-lint:
-	go install mvdan.cc/gofumpt@v0.2.0
-	test -z "$$(gofumpt -l -extra .)" 
-	go vet -stdmethods=false $$(go list ./...)
-
-bench:
-	go test -bench=. -benchmem -run=none ./...
-
-test:
-	go test -race -covermode=atomic -coverprofile=$(COV_PROF) ./...
-
-thriftgo:
-	go install
-
-testall: thriftgo
-	@set -e; for d in test/*; do $(MAKE) -C $$d; done
-
-clean:
-	rm -rf $(COV_PROF) $(IDL)
-
+all:
+	bash -x ./run.sh

--- a/test/fastgo/run.sh
+++ b/test/fastgo/run.sh
@@ -1,4 +1,4 @@
-# Copyright 2022 CloudWeGo Authors
+# Copyright 2024 CloudWeGo Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -11,33 +11,11 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-OUT=$(PWD)/testdata
-IDL=$(OUT)/x.thrift
-COV_PROF=$(OUT)/cov.out
-
-export IDL
-
-.PHONY: all clean
-all: lint test bench
-
-lint:
-	go install mvdan.cc/gofumpt@v0.2.0
-	test -z "$$(gofumpt -l -extra .)" 
-	go vet -stdmethods=false $$(go list ./...)
-
-bench:
-	go test -bench=. -benchmem -run=none ./...
-
-test:
-	go test -race -covermode=atomic -coverprofile=$(COV_PROF) ./...
-
-thriftgo:
-	go install
-
-testall: thriftgo
-	@set -e; for d in test/*; do $(MAKE) -C $$d; done
-
-clean:
-	rm -rf $(COV_PROF) $(IDL)
-
+#
+set -e
+thriftgo -g fastgo:no_default_serdes=true,gen_setter=true -o=. ./testdata.thrift
+cd testdata
+rm -f go.mod
+go mod init thriftgo/test/fastgo/testdata
+go mod tidy
+go build -v ./...

--- a/test/fastgo/testdata.thrift
+++ b/test/fastgo/testdata.thrift
@@ -1,0 +1,96 @@
+# Copyright 2024 CloudWeGo Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+namespace go testdata
+
+enum Numberz
+{
+  TEN = 10
+}
+
+typedef i64 UserID
+
+struct Msg
+{
+  1: string message;
+  2: i32 type;
+}
+
+struct TestTypes {
+  1: required bool FBool;
+  2: byte FByte;
+  3: i8 I8;
+  4: i16 I16;
+  5: i32 I32;
+  6: i64 I64;
+  7: double Double;
+  8: string String;
+  9: binary Binary;
+  10: Numberz Enum;
+  11: UserID UID;
+  12: Msg S;
+  20: required map<i32, i32> M0;
+  21: map<i32, string> M1;
+  22: map<i32, Msg> M2;
+  23: map<string, Msg> M3;
+  30: required list<i32> L0;
+  31: list<string> L1;
+  32: list<Msg> L2;
+  40: required set<i32> S0;
+  41: set<string> S1;
+  50: list<map<i32, i32>> LM;
+  60: map<i32, list<i32>> ML;
+}
+
+struct TestTypesOptional {
+  1: optional bool FBool;
+  2: optional byte FByte;
+  3: optional i8 I8;
+  4: optional i16 I16;
+  5: optional i32 I32;
+  6: optional i64 I64;
+  7: optional double Double;
+  8: optional string String;
+  9: optional binary Binary;
+  10: optional Numberz Enum;
+  11: optional UserID UID;
+  12: optional Msg S;
+  20: optional map<i32, i32> M0;
+  21: optional map<i32, string> M1;
+  22: optional map<i32, Msg> M2;
+  23: optional map<string, Msg> M3;
+  30: optional list<i32> L0;
+  31: optional list<string> L1;
+  32: optional list<Msg> L2;
+  40: optional set<i32> S0;
+  41: optional set<string> S1;
+  50: optional list<map<i32, i32>> LM;
+  60: optional map<i32, list<i32>> ML;
+}
+
+struct TestTypesWithDefault {
+  1: optional bool FBool = true;
+  2: optional byte FByte = 2;
+  3: optional i8 I8 = 3;
+  4: optional i16 I6 = 4;
+  5: optional i32 I32 = 5;
+  6: optional i64 I64 = 6;
+  7: optional double Double = 7;
+  8: optional string String = "8";
+  9: optional binary Binary = "8";
+  10: optional Numberz Enum = 10;
+  11: optional UserID UID = 11;
+  30: optional list<i32> L0 = [ 30 ];
+  40: optional set<i32> S0 = [ 40 ];
+}


### PR DESCRIPTION
## Description
new `FastAppend` method to replace `FastWrite`


## Motivation and Context
`FastWrite` can only be called after `BLength` which may cause performance and concurrency issues
