### PR TITLE
optimize: check and warn byte in thrift idl

### DIFF
--- a/semantic/checker.go
+++ b/semantic/checker.go
@@ -145,9 +145,26 @@ func (c *checker) CheckStructLikes(t *parser.Thrift) (warns []string, err error)
 				warns = append(warns, fmt.Sprintf("non-positive ID %d of field %q in %q",
 					f.ID, f.Name, s.Name))
 			}
+			if containByteType(f.Type) {
+				warns = append(warns, fmt.Sprintf("field %q in %q is still using 'byte'. The 'byte' type is a compatibility alias for 'i8'. Use 'i8' to emphasize the signedness of this type. If you want to generate '[]byte', please use 'binary' in thrift IDL.",
+					f.Name, s.Name))
+			}
 		}
 	}
 	return
+}
+
+func containByteType(t *parser.Type) bool {
+	if parser.Typename2TypeID(t.Name) == parser.BYTE {
+		return true
+	}
+	if t.KeyType != nil && containByteType(t.KeyType) {
+		return true
+	}
+	if t.ValueType != nil && containByteType(t.ValueType) {
+		return true
+	}
+	return false
 }
 
 // CheckUnions checks the semantics of union nodes.

--- a/version/version.go
+++ b/version/version.go
@@ -14,4 +14,4 @@
 
 package version
 
-const ThriftgoVersion = "0.3.18"
+const ThriftgoVersion = "0.3.19"


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
check and warn when there're 'byte' in thrift idl

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
'byte' is not recommended to use anymore.

## Related Issue
<!-- use words like 'fix #123', 'closes #123' -->
