### PR TITLE
optimize: add global descriptor release api

### DIFF
--- a/thrift_reflection/descriptor_register.go
+++ b/thrift_reflection/descriptor_register.go
@@ -227,6 +227,18 @@ func RegisterAST(ast *parser.Thrift) (*GlobalDescriptor, *FileDescriptor) {
 	return gd, fd
 }
 
+// ReleaseGlobalDescriptors release the global descriptor
+func ReleaseGlobalDescriptors(gds ...*GlobalDescriptor) {
+	if len(gds) == 0 {
+		return
+	}
+	lock.Lock()
+	defer lock.Unlock()
+	for _, gd := range gds {
+		delete(globalDescriptorMap, gd.uuid)
+	}
+}
+
 func generateShortUUID() string {
 	uuid := make([]byte, 4)
 	_, _ = rand.Read(uuid)

--- a/thrift_reflection/descriptor_register.go
+++ b/thrift_reflection/descriptor_register.go
@@ -235,6 +235,9 @@ func ReleaseGlobalDescriptors(gds ...*GlobalDescriptor) {
 	lock.Lock()
 	defer lock.Unlock()
 	for _, gd := range gds {
+		if gd == nil {
+			continue
+		}
 		delete(globalDescriptorMap, gd.uuid)
 	}
 }


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Add ReleaseGlobalDescriptors func to release global Descriptor

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

We use thrift_reflection in server to parse thrift files. However, as time goes by, the server will crash due to OOM, the root cause is that the globalDescriptorMap only increases but never decreases. Therefore, an API is needed to clean up the unused GD.
![image](https://github.com/user-attachments/assets/fac1509a-aba3-4ff4-9b00-7225a02b925c)



## Related Issue
<!-- use words like 'fix #123', 'closes #123' -->
