### PR TITLE
feat: support lua 5.3

### DIFF
--- a/wireshark/thrift.lua
+++ b/wireshark/thrift.lua
@@ -13,6 +13,18 @@
 -- limitations under the License.
 
 -------------------------------------------------------------------------------
+--- utils
+-- https://www.wireshark.org/docs/wsdg_html_chunked/_bitwise_operations.html
+-- Lua 5.3 and greater has native bitwise operators. 
+-- The bit32 library introduced in Lua 5.2 is in Lua 5.3, albeit deprecated, 
+-- but not present in Lua 5.4. For maximum backwards compatibility, 
+-- all versions of Wireshark with Lua support include the Lua BitOp library, 
+-- which has been ported to be compatible with Lua 5.3 and 5.4. The BitOp API reference
+-- is available at https://bitop.luajit.org/api.html. The API is similar to that of the bit32 
+-- library, and in many cases can function as a drop in replacement for code written to use that
+-- library by simply replacing a bit32 = require("bit32") statement with bit32 = bit.
+bit32 = bit
+
 --- protocols
 local ttheader_protocol = Proto("ttheader", "Thrift TTHeader Protocol")
 local tbinary_protocol = Proto("tbinary", "Thrift UnframedBinary Protocol")


### PR DESCRIPTION
## Description

feat: support lua 5.3

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Lua 5.3 and greater has native [bitwise operators](https://www.lua.org/manual/5.4/manual.html#3.4.2). The [bit32 library](https://www.lua.org/manual/5.2/manual.html#6.7) introduced in Lua 5.2 is in Lua 5.3, albeit [deprecated](https://www.lua.org/manual/5.3/manual.html#8), but not present in Lua 5.4. For maximum backwards compatibility, all versions of Wireshark with Lua support include the Lua BitOp library, which has been ported to be compatible with Lua 5.3 and 5.4. The BitOp API reference is available at https://bitop.luajit.org/api.html. The API is similar to that of the bit32 library, and in many cases can function as a drop in replacement for code written to use that library by simply replacing a bit32 = require("bit32") statement with bit32 = bit.

## Related Issue
<!-- use words like 'fix #123', 'closes #123' -->
