### PR TITLE
optimize: remove deep equal for frugal slim template

### DIFF
--- a/generator/golang/templates/slim/slim.go
+++ b/generator/golang/templates/slim/slim.go
@@ -132,12 +132,6 @@ func (p *{{$TypeName}}) Error() string {
 }
 {{- end}}
 
-{{- if Features.GenDeepEqual}}
-{{template "StructLikeDeepEqual" .}}
-
-{{template "StructLikeDeepEqualField" .}}
-{{- end}}
-
 {{InsertionPoint "ExtraFieldMap"}}
 {{- end}}{{/* define "StructLike" */}}
 	`


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
optimize: remove deep equal code for frugal slim template.
'template=slim' will no longer generate DeepEqual function for structs. If you need DeepEqual, then turn off 'template=slim'.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
To optimize codegen size.

## Related Issue
<!-- use words like 'fix #123', 'closes #123' -->
