### PR TITLE
fix: fix trimmer preserve files path

### DIFF
--- a/generator/golang/templates/ref/ref_tpl.go
+++ b/generator/golang/templates/ref/ref_tpl.go
@@ -107,6 +107,15 @@ var New{{$ClientName}}Protocol = {{$RefPackage}}.New{{$ClientName}}Protocol
 
 
 {{- end}}{{/* if not Features.NoProcessor */}}
+
+{{- range .Functions}}
+{{InsertionPoint "ExtraStruct"}}
+{{- if or .Streaming.ClientStreaming .Streaming.ServerStreaming}}
+{{- $arg := index .Arguments 0}}
+type {{.Service.GoName}}_{{.Name}}Server =  {{$RefPackage}}.{{.Service.GoName}}_{{.Name}}Server
+{{- end}}{{/* Streaming */}}
+{{- end}}{{/* range .Functions */}}
+
 `
 
 var constRef = `{{- $Consts := .Constants.GoConstants}}

--- a/tool/trimmer/trim/mark.go
+++ b/tool/trimmer/trim/mark.go
@@ -17,6 +17,8 @@ package trim
 import (
 	"strings"
 
+	"github.com/cloudwego/thriftgo/utils/dir_utils"
+
 	"github.com/cloudwego/thriftgo/parser"
 )
 
@@ -325,12 +327,19 @@ func (t *Trimmer) checkPreserve(theStruct *parser.StructLike) bool {
 func (t *Trimmer) loadPreserveFiles(ast *parser.Thrift, preserveFiles []string) {
 	preserveFilesMap := map[string]bool{}
 	for _, fn := range preserveFiles {
-		preserveFilesMap[fn] = true
+		// 下面对比部分，从 ast 里获取的 th.Filename 是当前命令行执行位置到对应IDL的相对路径文件名
+		// 但用户填写的 preserveFilesMap 可能是绝对的可能是相对的
+		// 这里统一转换为相对路径
+		relFn, err := dir_utils.ToRelative(fn)
+		if err != nil {
+			continue
+		}
+		preserveFilesMap[relFn] = true
 	}
 	t.preserveFileStructs = map[*parser.StructLike]bool{}
 	for th := range ast.DepthFirstSearch() {
 		if preserveFilesMap[th.Filename] {
-			for _, st := range ast.Structs {
+			for _, st := range th.Structs {
 				t.preserveFileStructs[st] = true
 			}
 		}

--- a/utils/dir_utils/dir_utils.go
+++ b/utils/dir_utils/dir_utils.go
@@ -17,7 +17,6 @@ package dir_utils
 import (
 	"os"
 	"path/filepath"
-	"strings"
 )
 
 var globalwd string
@@ -43,7 +42,7 @@ func Getwd() (string, error) {
 }
 
 func ToAbsolute(k string) (string, error) {
-	if !strings.HasSuffix(k, "/") {
+	if !filepath.IsAbs(k) {
 		wd, err := Getwd()
 		if err != nil {
 			return "", err
@@ -56,4 +55,20 @@ func ToAbsolute(k string) (string, error) {
 		k = absK
 	}
 	return k, nil
+}
+
+// ToRelative 将绝对路径转换为相对路径
+func ToRelative(path string) (string, error) {
+	if filepath.IsAbs(path) {
+		wd, err := Getwd()
+		if err != nil {
+			return "", err
+		}
+		relPath, err := filepath.Rel(wd, path)
+		if err != nil {
+			return "", err
+		}
+		path = relPath
+	}
+	return path, nil
 }


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
trimmer 裁切工具的 preserve files 配置，兼容相对路径写法和绝对路径写法匹配

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


## Related Issue
<!-- use words like 'fix #123', 'closes #123' -->
