### PR TITLE
fix: fix slim template no deep equal

### DIFF
--- a/generator/golang/option.go
+++ b/generator/golang/option.go
@@ -259,5 +259,12 @@ next:
 		}
 		cu.Info("unsupported option:", a)
 	}
+
+	// do not generate deep equal for slim template
+	// optimize: optimize slim template and unify no_default_serdes template
+	if cu.useTemplate == "slim" {
+		cu.features.GenDeepEqual = false
+	}
+
 	return nil
 }

--- a/generator/golang/templates/slim/slim.go
+++ b/generator/golang/templates/slim/slim.go
@@ -132,6 +132,12 @@ func (p *{{$TypeName}}) Error() string {
 }
 {{- end}}
 
+{{- if Features.GenDeepEqual}}
+{{template "StructLikeDeepEqual" .}}
+
+{{template "StructLikeDeepEqualField" .}}
+{{- end}}
+
 {{InsertionPoint "ExtraFieldMap"}}
 {{- end}}{{/* define "StructLike" */}}
 	`


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
fix thrift -no_default_serdes has no DeepEqual and make kitex fastCodec compiling error issue.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


## Related Issue
<!-- use words like 'fix #123', 'closes #123' -->
