### PR TITLE
fix: fix TTHeader wireshark dissector decoding TApplicationException failed

### DIFF
--- a/wireshark/thrift.lua
+++ b/wireshark/thrift.lua
@@ -287,7 +287,7 @@ function tbinary_protocol.dissector(buffer, pinfo, tree)
     local version = bit32.band(sz, THRIFT_VERSION_MASK)
 
     local tbuf = ThriftBuffer:new(buffer)
-    if sz < 0 and bit32.btest(version, THRIFT_VERSION_1) then
+    if sz < 0 and bit32.band(version, THRIFT_VERSION_1) ~= 0 then
         local type = bit32.band(sz, THRIFT_TYPE_MASK)
         tree:add(tbinary_fields.msg_type, type)
         tbuf(4) --- skip 4 bytes


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
脚本中实际使用的是 bit 库，并没有 bit32 中的 btest 函数，替换为 bit 中的 band 函数


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
使用 TTHeader wireshark dissector 解析 Server 返回的 ApplicationException 时失败：
![image](https://github.com/user-attachments/assets/b2bc5b75-6147-4789-8ca5-dfc6a71fd200)
修复后：
![image](https://github.com/user-attachments/assets/fdfa8167-d806-4d0b-9c7e-b44101290902)


## Related Issue
<!-- use words like 'fix #123', 'closes #123' -->
