### PR TITLE
fix: miss context import when only stream methods

### DIFF
--- a/generator/golang/templates/service.go
+++ b/generator/golang/templates/service.go
@@ -20,7 +20,7 @@ var FunctionSignature = `
 {{- $Function := .}}
 {{- if or .Streaming.ClientStreaming .Streaming.ServerStreaming}}
 	{{- $arg := index .Arguments 0}}
-	{{- .GoName}}({{- if Features.StreamX}}ctx context.Context,{{- end}}
+	{{- .GoName}}({{- if Features.StreamX}}{{- UseStdLibrary "context" -}}ctx context.Context,{{- end}}
 	{{- if and .Streaming.ServerStreaming (not .Streaming.ClientStreaming) -}}
 		req {{$arg.GoTypeName}},
 	{{- end -}}


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


## Related Issue
<!-- use words like 'fix #123', 'closes #123' -->
