### PR TITLE
feat: generate function TableName for GORM

### DIFF
--- a/generator/golang/templates/struct.go
+++ b/generator/golang/templates/struct.go
@@ -37,6 +37,16 @@ type {{$TypeName}} struct {
 	_fieldmask *fieldmask.FieldMask
 	{{- end}}
 }
+{{- if .Annotations}}
+// Annotations for {{$TypeName}}
+	{{- range $anno := .Annotations}}
+		{{- if eq $anno.Key "gorm.table_name" }}
+		func (p *{{$TypeName}}) TableName() string {
+			return "{{index $anno.Values 0}}"
+		}
+		{{- end}}
+	{{end}}
+{{- end}}
 
 {{- if Features.GenerateTypeMeta}}
 {{- UseStdLibrary "meta"}}
@@ -134,7 +144,6 @@ func (p *{{$TypeName}}) String() string {
 	{{- UseStdLibrary "fmt"}}
 	return fmt.Sprintf("{{$TypeName}}(%+v)", *p)
 	{{- end}}
-
 }
 
 {{- if eq .Category "exception"}}

--- a/test/golang/gorm/gorm_table.thrift
+++ b/test/golang/gorm/gorm_table.thrift
@@ -1,0 +1,20 @@
+namespace go test
+
+struct User {
+    1: i64 id;
+    2: string name (go.tag="json:\"json\" query:\"query\" form:\"form\" header:\"header\" goTag:\"taghhh\"");
+} (gorm.table_name = "users_table")
+
+struct Address {
+    1: i64 id;
+    2: string name (go.tag="json:\"json\" query:\"query\" form:\"form\" header:\"header\" goTag:\"taghhh\"");
+}
+
+// Only the first name will be used
+struct Order{
+    1: i64 id;
+    2: string name (go.tag="json:\"json\" query:\"query\" form:\"form\" header:\"header\" goTag:\"taghhh\"");
+} (
+    gorm.table_name = "order",
+    gorm.table_name = "order_table"
+    )


### PR DESCRIPTION
## Description
Generate a TableName function for GORM when the annotation gorm.table_name presents.

## Motivation and Context
Allow users to customise table names for structs.
This feature creates new TableName functions for the IDL below to return the table names specified by `gorm.table_name`.

```
namespace go test
// Case 1 with gorm.table_name
struct User {
    1: i64 id;
    2: string name;
} (gorm.table_name = "users_table")

// Case 2 without gorm.table_name
struct Address {
    1: i64 id;
    2: string name;
}

// Case 3 without two gorm.table_names, but only the first one will be used
struct Order{
    1: i64 id;
    2: string name;
} (
    gorm.table_name = "order",
    gorm.table_name = "order_table"
    )
```


## Related Issue
N/A