### PR TITLE
feat: add insertion point for typedef

### DIFF
--- a/generator/golang/templates/typedef.go
+++ b/generator/golang/templates/typedef.go
@@ -26,7 +26,7 @@ type {{$NewTypeName}} = {{$OldTypeName}}
 type {{$NewTypeName}} {{$OldTypeName}}
 {{- end}}
 
-{{InsertionPoint "typedef" $NewTypeName}}
+{{InsertionPoint "typedef" $NewTypeName.String}}
 
 {{if .Type.Category.IsStructLike}} 
 func New{{$NewTypeName}}() *{{$NewTypeName}} {

--- a/generator/golang/templates/typedef.go
+++ b/generator/golang/templates/typedef.go
@@ -26,6 +26,8 @@ type {{$NewTypeName}} = {{$OldTypeName}}
 type {{$NewTypeName}} {{$OldTypeName}}
 {{- end}}
 
+{{InsertionPoint "typedef" $NewTypeName}}
+
 {{if .Type.Category.IsStructLike}} 
 func New{{$NewTypeName}}() *{{$NewTypeName}} {
 	return (*{{$NewTypeName}})({{$OldTypeName.NewFunc}}())


### PR DESCRIPTION
## Description

Add an insertion point for typedef to provide convenience for plugins that add some stuff for typedef.

## Motivation and Context

I built a plugin to support string enums, it works like

```thrift
typedef string Person (
  datatype = "enum",
  datatype.enum.john = "john",
  datatype.enum.mary = "mary",
  datatype.enum.jack = "jack",
)
```

```bash
thriftgo -g go:use_type_alias=false,no_default_serdes -plugin datatype <path-to-thrift-file>
```

```go
type Person string

const (
	PersonJohn Person = "john"
	PersonMary Person = "mary"
	PersonJack Person = "jack"
)

func (v Person) IsValid() error {
	switch v {
	case PersonJohn:
		return nil
	case PersonMary:
		return nil
	case PersonJack:
		return nil
	default:
		return fmt.Errorf("invalid Person: %q", v)
	}
}

func PersonList() []Person {
	return []Person{
		PersonJohn,
		PersonMary,
		PersonJack,
	}
}
```

It works well; however, there's no `InsertionPoint` in the template for typedef, so I have to use the `eof` point, which makes the generated code hard to read: the additional code is far away from the definition of the type. 😢

## Related Issue

None.
