### PR TITLE
feat: support trimming enums and consts

### DIFF
--- a/tool/trimmer/test_cases/test_const/const_test.thrift
+++ b/tool/trimmer/test_cases/test_const/const_test.thrift
@@ -1,0 +1,29 @@
+// Copyright 2025 CloudWeGo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Test file for constant trimming functionality
+
+// These constants are defined but not used in the IDL
+const string UnusedString = "unused"
+const i32 UnusedNumber = 42
+const list<string> UnusedList = ["a", "b", "c"]
+
+struct TestStruct {
+    1: string name
+    2: i32 value
+}
+
+service TestService {
+    TestStruct test()
+}

--- a/tool/trimmer/test_cases/test_enum/base.thrift
+++ b/tool/trimmer/test_cases/test_enum/base.thrift
@@ -1,0 +1,34 @@
+// Copyright 2025 CloudWeGo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// This enum will be referenced and used
+enum AccountType {
+    FREE = 1,
+    PREMIUM = 2,
+    ENTERPRISE = 3
+}
+
+// This enum will not be used and should be trimmed
+enum UnusedLevel {
+    LEVEL1 = 1,
+    LEVEL2 = 2,
+    LEVEL3 = 3
+}
+
+// This enum will be used via typedef
+enum Country {
+    US = 1,
+    UK = 2,
+    CN = 3
+}

--- a/tool/trimmer/test_cases/test_enum/enum_test.thrift
+++ b/tool/trimmer/test_cases/test_enum/enum_test.thrift
@@ -1,0 +1,59 @@
+// Copyright 2025 CloudWeGo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// This enum is used by Person struct
+enum Status {
+    ACTIVE = 1,
+    INACTIVE = 2,
+    PENDING = 3
+}
+
+// This enum is NOT used anywhere and should be trimmed
+enum UnusedColor {
+    RED = 1,
+    GREEN = 2,
+    BLUE = 3
+}
+
+// This enum is used as a field type
+enum Gender {
+    MALE = 1,
+    FEMALE = 2,
+    OTHER = 3
+}
+
+// This enum is NOT used and should be trimmed
+enum UnusedPriority {
+    LOW = 1,
+    MEDIUM = 2,
+    HIGH = 3
+}
+
+// This enum is used in service method
+enum ResponseCode {
+    SUCCESS = 0,
+    ERROR = 1,
+    TIMEOUT = 2
+}
+
+struct Person {
+    1: string name
+    2: Status status
+    3: Gender gender
+}
+
+service TestService {
+    ResponseCode getStatus(1: string id)
+    Person getPerson(1: string id)
+}

--- a/tool/trimmer/test_cases/test_enum/include_test.thrift
+++ b/tool/trimmer/test_cases/test_enum/include_test.thrift
@@ -1,0 +1,27 @@
+// Copyright 2025 CloudWeGo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+include "base.thrift"
+
+typedef base.Country Location
+
+struct Account {
+    1: string username
+    2: base.AccountType type
+    3: Location location
+}
+
+service AccountService {
+    Account getAccount(1: string id)
+}

--- a/tool/trimmer/trim/config.go
+++ b/tool/trimmer/trim/config.go
@@ -31,6 +31,8 @@ type YamlArguments struct {
 	DisablePreserveComment *bool    `yaml:"disable_preserve_comment,omitempty"`
 	MatchGoName            *bool    `yaml:"match_go_name,omitempty"`
 	PreservedFiles         []string `yaml:"preserved_files,omitempty"`
+	TrimEnums              *bool    `yaml:"trim_enums,omitempty"`
+	TrimConsts             *bool    `yaml:"trim_consts,omitempty"`
 }
 
 func ParseYamlConfig(path string) *YamlArguments {

--- a/tool/trimmer/trim/mark.go
+++ b/tool/trimmer/trim/mark.go
@@ -180,6 +180,10 @@ func (t *Trimmer) markEnum(enum *parser.Enum, filename string) {
 	t.marks[filename][enum] = struct{}{}
 }
 
+func (t *Trimmer) markConstant(constant *parser.Constant, filename string) {
+	t.marks[filename][constant] = struct{}{}
+}
+
 func (t *Trimmer) markTypeDef(theType *parser.Type, ast *parser.Thrift, filename string) {
 	if theType.IsTypedef == nil {
 		return
@@ -232,9 +236,13 @@ func (t *Trimmer) markKeptPart(ast *parser.Thrift, filename string) (ret bool) {
 		keptPartCache[ast] = ret
 	}()
 
-	for _, constant := range ast.Constants {
-		t.markType(constant.Type, ast, filename)
-		ret = true
+	if !t.trimConsts {
+		// When trimConsts is disabled (default), mark all constants and their types
+		for _, constant := range ast.Constants {
+			t.markConstant(constant, filename)
+			t.markType(constant.Type, ast, filename)
+			ret = true
+		}
 	}
 
 	for _, typedef := range ast.Typedefs {

--- a/tool/trimmer/trim/traversal.go
+++ b/tool/trimmer/trim/traversal.go
@@ -25,8 +25,7 @@ func (t *Trimmer) traversal(ast *parser.Thrift, filename string) {
 	listInclude := make([]*parser.Include, 0, len(ast.Includes))
 	for i := range ast.Includes {
 		_, ok := currentMap[ast.Includes[i]]
-		if ok || len(ast.Includes[i].Reference.Constants)+
-			len(ast.Includes[i].Reference.Enums)+len(ast.Includes[i].Reference.Typedefs) > 0 {
+		if ok || t.shouldTraverseInclude(ast.Includes[i].Reference) {
 			t.traversal(ast.Includes[i].Reference, filename)
 			listInclude = append(listInclude, ast.Includes[i])
 		}
@@ -110,4 +109,17 @@ func (t *Trimmer) traversal(ast *parser.Thrift, filename string) {
 		ast.Constants = listConst
 		t.structsTrimmed -= len(ast.Constants)
 	}
+}
+
+func (t *Trimmer) shouldTraverseInclude(ast *parser.Thrift) bool {
+	if len(ast.Typedefs) > 0 {
+		return true
+	}
+	if !t.trimEnums && len(ast.Enums) > 0 {
+		return true
+	}
+	if !t.trimConsts && len(ast.Constants) > 0 {
+		return true
+	}
+	return false
 }

--- a/tool/trimmer/trim/traversal.go
+++ b/tool/trimmer/trim/traversal.go
@@ -88,4 +88,26 @@ func (t *Trimmer) traversal(ast *parser.Thrift, filename string) {
 	}
 
 	t.structsTrimmed -= len(ast.Structs) + len(ast.Includes) + len(ast.Services) + len(ast.Unions) + len(ast.Exceptions)
+	if t.trimEnums {
+		listEnum := make([]*parser.Enum, 0, len(ast.Enums))
+		for i := range ast.Enums {
+			_, ok := currentMap[ast.Enums[i]]
+			if ok {
+				listEnum = append(listEnum, ast.Enums[i])
+			}
+		}
+		ast.Enums = listEnum
+		t.structsTrimmed -= len(ast.Enums)
+	}
+	if t.trimConsts {
+		listConst := make([]*parser.Constant, 0, len(ast.Constants))
+		for i := range ast.Constants {
+			_, ok := currentMap[ast.Constants[i]]
+			if ok {
+				listConst = append(listConst, ast.Constants[i])
+			}
+		}
+		ast.Constants = listConst
+		t.structsTrimmed -= len(ast.Constants)
+	}
 }

--- a/tool/trimmer/trim/trimmer_api.go
+++ b/tool/trimmer/trim/trimmer_api.go
@@ -71,9 +71,6 @@ func recursiveDump(ast *parser.Thrift, trimmedContent map[string]string) error {
 	if err != nil {
 		return err
 	}
-	if main == "" {
-		return nil
-	}
 	trimmedContent[ast.Filename] = main
 
 	for _, inc := range ast.Includes {

--- a/tool/trimmer/trim/trimmer_api.go
+++ b/tool/trimmer/trim/trimmer_api.go
@@ -71,6 +71,9 @@ func recursiveDump(ast *parser.Thrift, trimmedContent map[string]string) error {
 	if err != nil {
 		return err
 	}
+	if main == "" {
+		return nil
+	}
 	trimmedContent[ast.Filename] = main
 
 	for _, inc := range ast.Includes {

--- a/tool/trimmer/trim/trimmer_test.go
+++ b/tool/trimmer/trim/trimmer_test.go
@@ -46,6 +46,8 @@ func TestSingleFile(t *testing.T) {
 	test.Assert(t, len(ast.Includes) == 2)
 	test.Assert(t, len(ast.Typedefs) == 5)
 	test.Assert(t, len(ast.Namespaces) == 1)
+	test.Assert(t, len(ast.Enums) == 1, fmt.Sprintf("Expected 1 enum after trimming, got %d", len(ast.Enums)))
+	test.Assert(t, ast.Enums[0].Name == "Gender", "Gender enum should be kept")
 	test.Assert(t, len(ast.Includes[0].Reference.Structs) == 2)
 	test.Assert(t, len(ast.Includes[0].Reference.Constants) == 2)
 	test.Assert(t, len(ast.Includes[0].Reference.Services) == 1)
@@ -126,4 +128,335 @@ func TestPreserve(t *testing.T) {
 	})
 	check(err)
 	test.Assert(t, len(ast.Structs) == 0)
+}
+
+// Test enum trimming functionality
+func TestEnumTrimming(t *testing.T) {
+	filename := filepath.Join("..", "test_cases", "test_enum", "enum_test.thrift")
+	ast, err := parser.ParseFile(filename, nil, true)
+	check(err)
+	if path := parser.CircleDetect(ast); len(path) > 0 {
+		check(fmt.Errorf("found include circle:\n\t%s", path))
+	}
+	checker := semantic.NewChecker(semantic.Options{FixWarnings: true})
+	_, err = checker.CheckAll(ast)
+	check(err)
+	check(semantic.ResolveSymbols(ast))
+
+	// Before trimming: should have 5 enums (Status, UnusedColor, Gender, UnusedPriority, ResponseCode)
+	test.Assert(t, len(ast.Enums) == 5, fmt.Sprintf("Expected 5 enums before trimming, got %d", len(ast.Enums)))
+
+	trimmer, err := newTrimmer(nil, "")
+	test.Assert(t, err == nil, err)
+	trimmer.asts[filename] = ast
+	trimmer.trimEnums = true
+	trimmer.markAST(ast)
+	trimmer.traversal(ast, ast.Filename)
+
+	// After trimming: should only have 3 enums (Status, Gender, ResponseCode)
+	// UnusedColor and UnusedPriority should be removed
+	test.Assert(t, len(ast.Enums) == 3, fmt.Sprintf("Expected 3 enums after trimming, got %d", len(ast.Enums)))
+
+	// Verify the correct enums are kept
+	enumNames := make(map[string]bool)
+	for _, enum := range ast.Enums {
+		enumNames[enum.Name] = true
+	}
+
+	test.Assert(t, enumNames["Status"], "Status enum should be kept")
+	test.Assert(t, enumNames["Gender"], "Gender enum should be kept")
+	test.Assert(t, enumNames["ResponseCode"], "ResponseCode enum should be kept")
+	test.Assert(t, !enumNames["UnusedColor"], "UnusedColor enum should be trimmed")
+	test.Assert(t, !enumNames["UnusedPriority"], "UnusedPriority enum should be trimmed")
+}
+
+// Test enum trimming with TrimAST API
+func TestEnumTrimmingWithAPI(t *testing.T) {
+	filename := filepath.Join("..", "test_cases", "test_enum", "enum_test.thrift")
+	ast, err := parser.ParseFile(filename, nil, true)
+	check(err)
+	if path := parser.CircleDetect(ast); len(path) > 0 {
+		check(fmt.Errorf("found include circle:\n\t%s", path))
+	}
+	checker := semantic.NewChecker(semantic.Options{FixWarnings: true})
+	_, err = checker.CheckAll(ast)
+	check(err)
+	check(semantic.ResolveSymbols(ast))
+
+	// Before trimming
+	test.Assert(t, len(ast.Enums) == 5, fmt.Sprintf("Expected 5 enums before trimming, got %d", len(ast.Enums)))
+
+	// Trim using TrimAST API
+	trimEnums := true
+	resultInfo, err := TrimAST(&TrimASTArg{
+		Ast:         ast,
+		TrimMethods: nil,
+		Preserve:    nil,
+		TrimEnums:   &trimEnums,
+	})
+	check(err)
+
+	// After trimming: should only have 3 enums
+	test.Assert(t, len(ast.Enums) == 3, fmt.Sprintf("Expected 3 enums after trimming, got %d", len(ast.Enums)))
+
+	// Verify result info includes enum counts
+	test.Assert(t, resultInfo != nil, "Result info should not be nil")
+	test.Assert(t, resultInfo.StructsTrimmed == 2, fmt.Sprintf("Expected 2 enums trimmed, got %d", resultInfo.StructsTrimmed))
+}
+
+// Test enum trimming with includes
+func TestEnumTrimmingWithIncludes(t *testing.T) {
+	filename := filepath.Join("..", "test_cases", "test_enum", "include_test.thrift")
+	ast, err := parser.ParseFile(filename, []string{filepath.Join("..", "test_cases", "test_enum")}, true)
+	check(err)
+	if path := parser.CircleDetect(ast); len(path) > 0 {
+		check(fmt.Errorf("found include circle:\n\t%s", path))
+	}
+	checker := semantic.NewChecker(semantic.Options{FixWarnings: true})
+	_, err = checker.CheckAll(ast)
+	check(err)
+	check(semantic.ResolveSymbols(ast))
+
+	// Before trimming: base.thrift has 3 enums
+	test.Assert(t, len(ast.Includes) == 1, "Should have 1 include")
+	baseAST := ast.Includes[0].Reference
+	test.Assert(t, len(baseAST.Enums) == 3, fmt.Sprintf("Expected 3 enums in base.thrift before trimming, got %d", len(baseAST.Enums)))
+
+	trimmer, err := newTrimmer(nil, "")
+	test.Assert(t, err == nil, err)
+	trimmer.asts[filename] = ast
+	trimmer.trimEnums = true
+	trimmer.markAST(ast)
+	trimmer.traversal(ast, ast.Filename)
+
+	// After trimming: base.thrift should only have 2 enums (AccountType and Country)
+	// UnusedLevel should be removed
+	test.Assert(t, len(baseAST.Enums) == 2, fmt.Sprintf("Expected 2 enums in base.thrift after trimming, got %d", len(baseAST.Enums)))
+
+	// Verify the correct enums are kept
+	enumNames := make(map[string]bool)
+	for _, enum := range baseAST.Enums {
+		enumNames[enum.Name] = true
+	}
+
+	test.Assert(t, enumNames["AccountType"], "AccountType enum should be kept")
+	test.Assert(t, enumNames["Country"], "Country enum should be kept (used via typedef)")
+	test.Assert(t, !enumNames["UnusedLevel"], "UnusedLevel enum should be trimmed")
+}
+
+// Test TrimBatchContentWithConfig API with enum trimming
+func TestTrimBatchContentWithConfigEnums(t *testing.T) {
+	// Read test files
+	enumTestContent := `
+enum UsedEnum {
+    VALUE1 = 1,
+    VALUE2 = 2
+}
+
+enum UnusedEnum {
+    VALUE3 = 1,
+    VALUE4 = 2
+}
+
+struct TestStruct {
+    1: UsedEnum field
+}
+
+service TestService {
+    TestStruct test()
+}
+`
+
+	IDLFileContentMap := map[string]string{
+		"test.thrift": enumTestContent,
+	}
+
+	// Trim the content
+	trimEnums := true
+	trimmedContent, err := TrimBatchContentWithConfig("test.thrift", IDLFileContentMap, TrimASTArg{
+		TrimMethods: nil,
+		Preserve:    nil,
+		TrimEnums:   &trimEnums,
+	})
+	test.Assert(t, err == nil, err)
+	test.Assert(t, trimmedContent != nil, "Trimmed content should not be nil")
+
+	// Parse the trimmed result to verify
+	ast, err := parser.ParseString("test.thrift", trimmedContent["test.thrift"])
+	test.Assert(t, err == nil, err)
+
+	// Should only have UsedEnum, UnusedEnum should be removed
+	test.Assert(t, len(ast.Enums) == 1, fmt.Sprintf("Expected 1 enum after trimming, got %d", len(ast.Enums)))
+	test.Assert(t, ast.Enums[0].Name == "UsedEnum", fmt.Sprintf("Expected UsedEnum, got %s", ast.Enums[0].Name))
+}
+
+// Test backward compatibility: enums should NOT be trimmed by default
+func TestEnumBackwardCompatibility(t *testing.T) {
+	filename := filepath.Join("..", "test_cases", "test_enum", "enum_test.thrift")
+	ast, err := parser.ParseFile(filename, nil, true)
+	check(err)
+	if path := parser.CircleDetect(ast); len(path) > 0 {
+		check(fmt.Errorf("found include circle:\n\t%s", path))
+	}
+	checker := semantic.NewChecker(semantic.Options{FixWarnings: true})
+	_, err = checker.CheckAll(ast)
+	check(err)
+	check(semantic.ResolveSymbols(ast))
+
+	// Before trimming: should have 5 enums
+	test.Assert(t, len(ast.Enums) == 5, fmt.Sprintf("Expected 5 enums before trimming, got %d", len(ast.Enums)))
+
+	// Trim WITHOUT setting TrimEnums (test default behavior)
+	trimmer, err := newTrimmer(nil, "")
+	test.Assert(t, err == nil, err)
+	trimmer.asts[filename] = ast
+	// Note: NOT setting trimmer.trimEnums = true
+	trimmer.markAST(ast)
+	trimmer.traversal(ast, ast.Filename)
+
+	// After trimming: should STILL have 5 enums (backward compatibility)
+	test.Assert(t, len(ast.Enums) == 5, fmt.Sprintf("Expected 5 enums after trimming (backward compatibility), got %d", len(ast.Enums)))
+}
+
+// Test backward compatibility with TrimAST API
+func TestEnumBackwardCompatibilityWithAPI(t *testing.T) {
+	filename := filepath.Join("..", "test_cases", "test_enum", "enum_test.thrift")
+	ast, err := parser.ParseFile(filename, nil, true)
+	check(err)
+	if path := parser.CircleDetect(ast); len(path) > 0 {
+		check(fmt.Errorf("found include circle:\n\t%s", path))
+	}
+	checker := semantic.NewChecker(semantic.Options{FixWarnings: true})
+	_, err = checker.CheckAll(ast)
+	check(err)
+	check(semantic.ResolveSymbols(ast))
+
+	// Before trimming
+	test.Assert(t, len(ast.Enums) == 5, fmt.Sprintf("Expected 5 enums before trimming, got %d", len(ast.Enums)))
+
+	// Trim using TrimAST API WITHOUT setting TrimEnums
+	_, err = TrimAST(&TrimASTArg{
+		Ast:         ast,
+		TrimMethods: nil,
+		Preserve:    nil,
+		// TrimEnums not set - should default to false
+	})
+	check(err)
+
+	// After trimming: should STILL have 5 enums (backward compatibility)
+	test.Assert(t, len(ast.Enums) == 5, fmt.Sprintf("Expected 5 enums after trimming (backward compatibility), got %d", len(ast.Enums)))
+}
+
+// Test constant trimming functionality
+func TestConstTrimming(t *testing.T) {
+	filename := filepath.Join("..", "test_cases", "test_const", "const_test.thrift")
+	ast, err := parser.ParseFile(filename, nil, true)
+	check(err)
+	if path := parser.CircleDetect(ast); len(path) > 0 {
+		check(fmt.Errorf("found include circle:\n\t%s", path))
+	}
+	checker := semantic.NewChecker(semantic.Options{FixWarnings: true})
+	_, err = checker.CheckAll(ast)
+	check(err)
+	check(semantic.ResolveSymbols(ast))
+
+	// Before trimming: should have 3 constants
+	test.Assert(t, len(ast.Constants) == 3, fmt.Sprintf("Expected 3 constants before trimming, got %d", len(ast.Constants)))
+
+	trimmer, err := newTrimmer(nil, "")
+	test.Assert(t, err == nil, err)
+	trimmer.asts[filename] = ast
+	trimmer.trimConsts = true
+	trimmer.markAST(ast)
+	trimmer.traversal(ast, ast.Filename)
+
+	// After trimming: should have 0 constants (all unused)
+	test.Assert(t, len(ast.Constants) == 0, fmt.Sprintf("Expected 0 constants after trimming, got %d", len(ast.Constants)))
+}
+
+// Test constant trimming with TrimAST API
+func TestConstTrimmingWithAPI(t *testing.T) {
+	filename := filepath.Join("..", "test_cases", "test_const", "const_test.thrift")
+	ast, err := parser.ParseFile(filename, nil, true)
+	check(err)
+	if path := parser.CircleDetect(ast); len(path) > 0 {
+		check(fmt.Errorf("found include circle:\n\t%s", path))
+	}
+	checker := semantic.NewChecker(semantic.Options{FixWarnings: true})
+	_, err = checker.CheckAll(ast)
+	check(err)
+	check(semantic.ResolveSymbols(ast))
+
+	// Before trimming
+	test.Assert(t, len(ast.Constants) == 3, fmt.Sprintf("Expected 3 constants before trimming, got %d", len(ast.Constants)))
+
+	// Trim using TrimAST API
+	trimConsts := true
+	resultInfo, err := TrimAST(&TrimASTArg{
+		Ast:        ast,
+		TrimConsts: &trimConsts,
+	})
+	check(err)
+
+	// After trimming: should have 0 constants
+	test.Assert(t, len(ast.Constants) == 0, fmt.Sprintf("Expected 0 constants after trimming, got %d", len(ast.Constants)))
+
+	// Verify result info includes constant counts
+	test.Assert(t, resultInfo != nil, "Result info should not be nil")
+	test.Assert(t, resultInfo.StructsTrimmed == 3, fmt.Sprintf("Expected 3 constants trimmed, got %d", resultInfo.StructsTrimmed))
+}
+
+// Test backward compatibility: constants should NOT be trimmed by default
+func TestConstBackwardCompatibility(t *testing.T) {
+	filename := filepath.Join("..", "test_cases", "test_const", "const_test.thrift")
+	ast, err := parser.ParseFile(filename, nil, true)
+	check(err)
+	if path := parser.CircleDetect(ast); len(path) > 0 {
+		check(fmt.Errorf("found include circle:\n\t%s", path))
+	}
+	checker := semantic.NewChecker(semantic.Options{FixWarnings: true})
+	_, err = checker.CheckAll(ast)
+	check(err)
+	check(semantic.ResolveSymbols(ast))
+
+	// Before trimming
+	test.Assert(t, len(ast.Constants) == 3, fmt.Sprintf("Expected 3 constants before trimming, got %d", len(ast.Constants)))
+
+	// Trim WITHOUT setting TrimConsts (test default behavior)
+	trimmer, err := newTrimmer(nil, "")
+	test.Assert(t, err == nil, err)
+	trimmer.asts[filename] = ast
+	// Note: NOT setting trimmer.trimConsts = true
+	trimmer.markAST(ast)
+	trimmer.traversal(ast, ast.Filename)
+
+	// After trimming: should STILL have 3 constants (backward compatibility)
+	test.Assert(t, len(ast.Constants) == 3, fmt.Sprintf("Expected 3 constants after trimming (backward compatibility), got %d", len(ast.Constants)))
+}
+
+// Test backward compatibility with TrimAST API
+func TestConstBackwardCompatibilityWithAPI(t *testing.T) {
+	filename := filepath.Join("..", "test_cases", "test_const", "const_test.thrift")
+	ast, err := parser.ParseFile(filename, nil, true)
+	check(err)
+	if path := parser.CircleDetect(ast); len(path) > 0 {
+		check(fmt.Errorf("found include circle:\n\t%s", path))
+	}
+	checker := semantic.NewChecker(semantic.Options{FixWarnings: true})
+	_, err = checker.CheckAll(ast)
+	check(err)
+	check(semantic.ResolveSymbols(ast))
+
+	// Before trimming
+	test.Assert(t, len(ast.Constants) == 3, fmt.Sprintf("Expected 3 constants before trimming, got %d", len(ast.Constants)))
+
+	// Trim using TrimAST API WITHOUT setting TrimConsts
+	_, err = TrimAST(&TrimASTArg{
+		Ast: ast,
+		// TrimConsts not set - should default to false
+	})
+	check(err)
+
+	// After trimming: should STILL have 3 constants (backward compatibility)
+	test.Assert(t, len(ast.Constants) == 3, fmt.Sprintf("Expected 3 constants after trimming (backward compatibility), got %d", len(ast.Constants)))
 }


### PR DESCRIPTION
## Description
trimmer 支持裁切 Enum 和 Const。
为了不造成 Breaking Change，添加```TrimEnums```和```TrimConsts```配置，用户需要主动设置才能开启。
<!--- Describe your changes in detail -->


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


## Related Issue
<!-- use words like 'fix #123', 'closes #123' -->
