### PR TITLE
fix: enum Value() always return int64 for driver.Value

### DIFF
--- a/generator/golang/templates/enum.go
+++ b/generator/golang/templates/enum.go
@@ -86,7 +86,7 @@ func (p *{{$EnumType}}) Value() (driver.Value, error) {
 	if p == nil {
 		return nil, nil
 	}
-	return int{{if Features.EnumAsINT32}}32{{else}}64{{end}}(*p), nil
+	return int64(*p), nil
 }
 {{- end}}{{/* if .Features.ScanValueForEnum */}}
 


### PR DESCRIPTION
## Description
修复生成代码与 sql 驱动的接口定义不一致的问题

## Motivation and Context
当 hertztool 使用类似 
``` shell
hertztool update -idl=$(thrift_dir) -t=template=slim -t=gen_setter=true --t=trim_idl -t=enum_as_int_32 -t=scan_value_for_enum=true
```
这样的方式生成代码时，结果中的枚举定义会是
<img width="1350" height="968" alt="image" src="https://github.com/user-attachments/assets/5ba09dec-46ce-4104-b93d-b0b1f22d0e14" />
但是，driver.Value 所支持的类型中并没有 int32，会导致运行时错误
<img width="1686" height="918" alt="image" src="https://github.com/user-attachments/assets/73a1ca10-1a77-4fd3-82f3-7a30a0dda17f" />
追查了下，是在使用 thriftgo 生成时，这里被错误处理了，应该直接转为 int64