### PR TITLE
chore: bump v0.4.5

### DIFF
--- a/version/version.go
+++ b/version/version.go
@@ -14,4 +14,4 @@
 
 package version
 
-const ThriftgoVersion = "0.4.3"
+const ThriftgoVersion = "0.4.5"


### PR DESCRIPTION
v0.4.4 tagged, use v0.4.5 instead

